### PR TITLE
Fix build script and type usage

### DIFF
--- a/convex/forum.ts
+++ b/convex/forum.ts
@@ -7,7 +7,7 @@ export const getTopics = query({
   args: {
     paginationOpts: v.object({
       numItems: v.number(),
-      cursor: v.optional(v.union(v.string(), v.null())),
+      cursor: v.union(v.string(), v.null()),
       id: v.optional(v.number()),
     }),
     category: v.optional(v.string()),

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "tsc ; vite build",
-    "build-no-errors": "tsc ; vite build",
+    "build": "tsc && vite build",
+    "build-no-errors": "tsc && vite build",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview",
     "types:supabase": "npx supabase gen types typescript --project-id $SUPABASE_PROJECT_ID > src/types/supabase.ts"

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -130,7 +130,7 @@ export function Navbar() {
                 <SignInButton
                   mode="modal"
                   signUpFallbackRedirectUrl="/dashboard"
-                  signInFallbackRedirectUrl="/dashboard"
+                  fallbackRedirectUrl="/dashboard"
                 >
                   <Button className="neumorphic-button h-10 px-6 text-sm text-[#2d3748] bg-transparent font-semibold border-0 shadow-none transition-all hover:scale-105 active:scale-95">
                     Masuk

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -118,7 +118,7 @@ function App() {
                     <SignInButton
                       mode="modal"
                       signUpFallbackRedirectUrl="/dashboard"
-                      signInFallbackRedirectUrl="/dashboard"
+                      fallbackRedirectUrl="/dashboard"
                     >
                       <Button className="neumorphic-button h-14 px-10 text-lg text-[#2d3748] bg-transparent font-semibold border-0 shadow-none transition-all">
                         <ArrowRight className="mr-2 h-5 w-5" />

--- a/src/pages/marketplace-sell.tsx
+++ b/src/pages/marketplace-sell.tsx
@@ -75,8 +75,10 @@ export default function MarketplaceSell() {
     description: "",
     price: "",
     originalPrice: "",
+    size: "",
     location: "",
     shippingMethods: [] as string[],
+    tags: [] as string[],
     isNegotiable: false,
     images: [] as string[],
   });
@@ -168,7 +170,9 @@ export default function MarketplaceSell() {
           ? parseInt(formData.originalPrice)
           : undefined,
         location: formData.location.trim(),
-        shippingMethods: formData.shippingMethods,
+        size: formData.size,
+        shippingOptions: formData.shippingMethods,
+        tags: formData.tags,
         isNegotiable: formData.isNegotiable,
         images: formData.images,
       });

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -48,9 +48,10 @@ function ProfileContent() {
     userData ? { authorId: userData._id } : "skip",
   );
 
-  const formatDate = (timestamp: number | undefined) => {
+  const formatDate = (timestamp: number | Date | undefined) => {
     if (!timestamp) return "—";
-    return new Date(timestamp).toLocaleDateString("id-ID", {
+    const date = typeof timestamp === "number" ? new Date(timestamp) : timestamp;
+    return date.toLocaleDateString("id-ID", {
       year: "numeric",
       month: "long",
       day: "numeric",


### PR DESCRIPTION
## Summary
- fix sign-in redirect props in Navbar and Home
- extend `formatDate` utility to handle Date objects
- include `size` and `tags` when selling a product
- adjust pagination validator for forum query
- ensure TypeScript compilation errors stop the build

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npx tsc --noEmit` *(fails to compile due to existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6857943e15a4832781daae45e41f324d