### PR TITLE
Add user points and badges

### DIFF
--- a/convex/forum.ts
+++ b/convex/forum.ts
@@ -149,7 +149,7 @@ export const createTopic = mutation({
 
     const now = Date.now();
 
-    const topicId = await ctx.db.insert("topics", {
+  const topicId = await ctx.db.insert("topics", {
       title: args.title,
       content: args.content,
       category: args.category,
@@ -164,15 +164,20 @@ export const createTopic = mutation({
       videoUrls: args.videoUrls,
       createdAt: now,
       updatedAt: now,
-    });
+  });
 
-    // Update category count setelah topic dibuat
-    await ctx.scheduler.runAfter(0, "forum:updateCategoryCount", {
-      categoryName: args.category,
-    });
+  // Update category count setelah topic dibuat
+  await ctx.scheduler.runAfter(0, "forum:updateCategoryCount", {
+    categoryName: args.category,
+  });
 
-    return topicId;
-  },
+  await ctx.scheduler.runAfter(0, "users:addUserPoints", {
+    userId: user._id,
+    points: 10,
+  });
+
+  return topicId;
+},
 });
 
 // Mutation untuk like/unlike topik
@@ -267,17 +272,24 @@ export const createComment = mutation({
       throw new Error("User tidak ditemukan");
     }
 
-    const now = Date.now();
+  const now = Date.now();
 
-    return await ctx.db.insert("comments", {
-      topicId: args.topicId,
-      content: args.content,
-      authorId: user._id,
-      authorName: user.name || "Anonymous",
-      likes: 0,
-      createdAt: now,
-      updatedAt: now,
-    });
+  const commentId = await ctx.db.insert("comments", {
+    topicId: args.topicId,
+    content: args.content,
+    authorId: user._id,
+    authorName: user.name || "Anonymous",
+    likes: 0,
+    createdAt: now,
+    updatedAt: now,
+  });
+
+  await ctx.scheduler.runAfter(0, "users:addUserPoints", {
+    userId: user._id,
+    points: 2,
+  });
+
+  return commentId;
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -264,6 +264,8 @@ export default defineSchema({
     whatsapp: v.optional(v.string()),
     instagram: v.optional(v.string()),
     avatar: v.optional(v.string()),
+    points: v.number(),
+    badges: v.array(v.string()),
     isVerified: v.boolean(),
     rating: v.number(),
     totalReviews: v.number(),

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -37,6 +37,11 @@ function ProfileContent() {
     user?.id ? { tokenIdentifier: user.id } : "skip",
   );
 
+  const userProfile = useQuery(
+    api.marketplace.getUserProfile,
+    userData ? { userId: userData._id } : "skip",
+  );
+
   // Query untuk mendapatkan statistik user dari forum
   const userTopics = useQuery(
     api.forum.getTopicsByAuthor,
@@ -76,6 +81,8 @@ function ProfileContent() {
     (sum, topic) => sum + topic.views,
     0,
   );
+  const points = userProfile?.profile?.points || 0;
+  const badges = userProfile?.profile?.badges || [];
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
@@ -134,6 +141,16 @@ function ProfileContent() {
                         Terverifikasi
                       </Badge>
                     )}
+                    {badges.map((b: string) => (
+                      <Badge
+                        key={b}
+                        variant="secondary"
+                        className="neumorphic-button-sm bg-transparent text-[#667eea] border-0 shadow-none"
+                      >
+                        <Trophy className="h-3 w-3 mr-1" />
+                        {b}
+                      </Badge>
+                    ))}
                   </div>
                 </div>
 
@@ -185,6 +202,15 @@ function ProfileContent() {
                     </div>
                     <span className="text-sm font-semibold text-[#1D1D1F]">
                       {totalViews}
+                    </span>
+                  </div>
+                  <div className="flex justify-between items-center">
+                    <div className="flex items-center gap-2">
+                      <Trophy className="h-4 w-4 text-[#667eea]" />
+                      <span className="text-sm text-[#86868B]">Poin</span>
+                    </div>
+                    <span className="text-sm font-semibold text-[#1D1D1F]">
+                      {points}
                     </span>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- include `points` and `badges` fields on `userProfiles`
- ensure profiles exist when creating/updating users
- add mutation to increase user points and grant badges
- award points on topic and comment creation
- show user points and badges on profile page

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build-no-errors` *(fails: missing React dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68579a83df18832786066866a530e1ac