### PR TITLE
Add tag filtering to forum

### DIFF
--- a/convex/forum.ts
+++ b/convex/forum.ts
@@ -13,6 +13,7 @@ export const getTopics = query({
     category: v.optional(v.string()),
     sortBy: v.optional(v.string()),
     searchQuery: v.optional(v.string()),
+    tag: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     let query: any = ctx.db.query("topics");
@@ -37,9 +38,11 @@ export const getTopics = query({
     const { id, ...paginationOpts } = args.paginationOpts;
     const topics = await query.paginate(paginationOpts);
 
+    let filteredPage = topics.page;
+
     // Filter berdasarkan search query jika ada
     if (args.searchQuery) {
-      const filteredTopics = topics.page.filter(
+      filteredPage = filteredPage.filter(
         (topic) =>
           topic.title.toLowerCase().includes(args.searchQuery!.toLowerCase()) ||
           topic.content
@@ -49,13 +52,19 @@ export const getTopics = query({
             .toLowerCase()
             .includes(args.searchQuery!.toLowerCase()),
       );
-      return {
-        ...topics,
-        page: filteredTopics,
-      };
     }
 
-    return topics;
+    // Filter berdasarkan tag jika ada
+    if (args.tag) {
+      filteredPage = filteredPage.filter((topic) =>
+        topic.tags.includes(args.tag!),
+      );
+    }
+
+    return {
+      ...topics,
+      page: filteredPage,
+    };
   },
 });
 
@@ -339,6 +348,21 @@ export const getCategories = query({
     );
 
     return categoriesWithRealCount;
+  },
+});
+
+// Query untuk mendapatkan semua tag unik
+export const getAllTags = query({
+  handler: async (ctx) => {
+    const topics = await ctx.db.query("topics").collect();
+    const tagSet = new Set<string>();
+    for (const topic of topics) {
+      for (const tag of topic.tags) {
+        const trimmed = tag.trim();
+        if (trimmed) tagSet.add(trimmed);
+      }
+    }
+    return Array.from(tagSet);
   },
 });
 

--- a/src/pages/forum.tsx
+++ b/src/pages/forum.tsx
@@ -12,6 +12,13 @@ import { Badge } from "@/components/ui/badge";
 import { Textarea } from "@/components/ui/textarea";
 import { Input } from "@/components/ui/input";
 import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import {
   Dialog,
   DialogContent,
   DialogDescription,
@@ -89,10 +96,12 @@ export default function Forum() {
   );
   const [embeddedVideos, setEmbeddedVideos] = useState<VideoData[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<"newest" | "popular" | "unanswered">(
     "newest",
   );
   const [searchQuery, setSearchQuery] = useState("");
+  const [newTopicTags, setNewTopicTags] = useState("");
   const [selectedTopic, setSelectedTopic] = useState<Topic | null>(null);
   const [isTopicDetailOpen, setIsTopicDetailOpen] = useState(false);
   const [newCommentContent, setNewCommentContent] = useState("");
@@ -105,12 +114,14 @@ export default function Forum() {
       category: selectedCategory || undefined,
       sortBy: sortBy,
       searchQuery: searchQuery || undefined,
+      tag: selectedTag || undefined,
     },
     { initialNumItems: 10 },
   );
 
   const forumStats = useQuery(api.forum.getForumStats);
   const categories = useQuery(api.forum.getCategories);
+  const allTags = useQuery(api.forum.getAllTags);
   const createTopicMutation = useMutation(api.forum.createTopic);
   const toggleLikeMutation = useMutation(api.forum.toggleTopicLike);
   const incrementViewsMutation = useMutation(api.forum.incrementTopicViews);
@@ -167,7 +178,10 @@ export default function Forum() {
         title: newTopicTitle,
         content: newTopicContent,
         category: newTopicCategory,
-        tags: [],
+        tags: newTopicTags
+          .split(",")
+          .map((t) => t.trim())
+          .filter((t) => t.length > 0),
         hasVideo: embeddedVideos.length > 0,
         videoUrls: embeddedVideos.map((v) => v.url),
       });
@@ -175,6 +189,7 @@ export default function Forum() {
       // Reset form
       setNewTopicTitle("");
       setNewTopicContent("");
+      setNewTopicTags("");
       setEmbeddedVideos([]);
       setIsNewTopicOpen(false);
 
@@ -451,6 +466,24 @@ export default function Forum() {
                       onChange={(e) => setSearchQuery(e.target.value)}
                       className="neumorphic-input border-0 flex-1"
                     />
+                    <Select
+                      value={selectedTag || ""}
+                      onValueChange={(val) =>
+                        setSelectedTag(val === "" ? null : val)
+                      }
+                    >
+                      <SelectTrigger className="neumorphic-input border-0 w-full sm:w-48">
+                        <SelectValue placeholder="Filter Tag" />
+                      </SelectTrigger>
+                      <SelectContent className="neumorphic-card border-0">
+                        <SelectItem value="">Semua Tag</SelectItem>
+                        {allTags?.map((tag) => (
+                          <SelectItem key={tag} value={tag}>
+                            {tag}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
                     {selectedCategory && (
                       <Button
                         onClick={() => setSelectedCategory(null)}
@@ -539,13 +572,25 @@ export default function Forum() {
                             <label className="text-sm font-medium text-[#2d3748]">
                               Konten
                             </label>
-                            <Textarea
+                          <Textarea
                               placeholder="Tulis konten topik Anda di sini... Bagikan pengalaman, ajukan pertanyaan, atau mulai diskusi menarik!"
                               value={newTopicContent}
                               onChange={(e) =>
                                 setNewTopicContent(e.target.value)
                               }
                               className="neumorphic-input border-0 min-h-[120px] resize-none"
+                            />
+                          </div>
+
+                          <div className="space-y-2">
+                            <label className="text-sm font-medium text-[#2d3748]">
+                              Tags (pisahkan dengan koma)
+                            </label>
+                            <Input
+                              placeholder="contoh: fruity, sweet"
+                              value={newTopicTags}
+                              onChange={(e) => setNewTopicTags(e.target.value)}
+                              className="neumorphic-input border-0"
                             />
                           </div>
 


### PR DESCRIPTION
## Summary
- add tag filters to `getTopics`
- expose `getAllTags` to fetch unique tags
- allow creating topics with tags
- add tag filter dropdown and tag input on forum page

## Testing
- `npm run lint` *(fails: couldn't find ESLint config)*
- `npm run build-no-errors` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68579dd249348327b0943fd457971ee6