### PR TITLE
Add simple contribution points feature

### DIFF
--- a/convex/forum.ts
+++ b/convex/forum.ts
@@ -166,6 +166,14 @@ export const createTopic = mutation({
       updatedAt: now,
     });
 
+    // Tambah poin untuk user
+    const newPoints = (user.points || 0) + 10;
+    const newBadges = user.badges || [];
+    if (newPoints >= 100 && !newBadges.includes("Kontributor Aktif")) {
+      newBadges.push("Kontributor Aktif");
+    }
+    await ctx.db.patch(user._id, { points: newPoints, badges: newBadges });
+
     // Update category count setelah topic dibuat
     await ctx.scheduler.runAfter(
       0,
@@ -273,7 +281,7 @@ export const createComment = mutation({
 
     const now = Date.now();
 
-    return await ctx.db.insert("comments", {
+    const commentId = await ctx.db.insert("comments", {
       topicId: args.topicId,
       content: args.content,
       authorId: user._id,
@@ -282,6 +290,16 @@ export const createComment = mutation({
       createdAt: now,
       updatedAt: now,
     });
+
+    // Tambah poin untuk user
+    const newPoints = (user.points || 0) + 5;
+    const newBadges = user.badges || [];
+    if (newPoints >= 100 && !newBadges.includes("Kontributor Aktif")) {
+      newBadges.push("Kontributor Aktif");
+    }
+    await ctx.db.patch(user._id, { points: newPoints, badges: newBadges });
+
+    return commentId;
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -7,6 +7,8 @@ export default defineSchema({
     email: v.optional(v.string()),
     image: v.optional(v.string()),
     tokenIdentifier: v.string(),
+    points: v.optional(v.number()),
+    badges: v.optional(v.array(v.string())),
   }).index("by_token", ["tokenIdentifier"]),
 
   categories: defineTable({

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -43,22 +43,26 @@ export const createOrUpdateUser = mutation({
       )
       .unique();
 
-    if (existingUser) {
-      // Update if needed
-      if (existingUser.name !== identity.name || existingUser.email !== identity.email) {
-        await ctx.db.patch(existingUser._id, {
-          name: identity.name,
-          email: identity.email,
-        });
-      }
-      return existingUser;
+  if (existingUser) {
+    const patch: any = {};
+    if (existingUser.name !== identity.name) patch.name = identity.name;
+    if (existingUser.email !== identity.email) patch.email = identity.email;
+    if (existingUser.points === undefined) patch.points = 0;
+    if (existingUser.badges === undefined) patch.badges = [];
+    if (Object.keys(patch).length > 0) {
+      await ctx.db.patch(existingUser._id, patch);
+      return { ...existingUser, ...patch };
     }
+    return existingUser;
+  }
 
     // Create new user
     const userId = await ctx.db.insert("users", {
       name: identity.name,
       email: identity.email,
       tokenIdentifier: identity.subject,
+      points: 0,
+      badges: [],
     });
 
     return await ctx.db.get(userId);

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -124,6 +124,13 @@ function ProfileContent() {
                       <Trophy className="h-3 w-3 mr-1" />
                       Enthusiast
                     </Badge>
+                    <Badge
+                      variant="secondary"
+                      className="neumorphic-button-sm bg-transparent text-[#667eea] border-0 shadow-none"
+                    >
+                      <Trophy className="h-3 w-3 mr-1" />
+                      {userData?.points || 0} Poin
+                    </Badge>
                     {user?.primaryEmailAddress?.verification.status ===
                       "verified" && (
                       <Badge
@@ -187,11 +194,40 @@ function ProfileContent() {
                       {totalViews}
                     </span>
                   </div>
-                </div>
+                  <div className="flex justify-between items-center">
+                    <div className="flex items-center gap-2">
+                      <Trophy className="h-4 w-4 text-[#667eea]" />
+                      <span className="text-sm text-[#86868B]">Poin</span>
+                    </div>
+                    <span className="text-sm font-semibold text-[#1D1D1F]">
+                      {userData?.points || 0}
+                    </span>
+                  </div>
               </div>
             </div>
 
-            {/* Main Content */}
+            {userData?.badges && userData.badges.length > 0 && (
+              <div className="neumorphic-card p-6 mt-6">
+                <h3 className="text-lg font-semibold text-[#1D1D1F] mb-4">
+                  Badge
+                </h3>
+                <div className="flex flex-wrap gap-2">
+                  {userData.badges.map((badge, idx) => (
+                    <Badge
+                      key={idx}
+                      variant="outline"
+                      className="neumorphic-button-sm px-3 py-1"
+                    >
+                      <Star className="h-3 w-3 mr-1" />
+                      {badge}
+                    </Badge>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+
+          {/* Main Content */}
             <div className="lg:col-span-2 space-y-8">
               {/* Account Information */}
               <Card className="neumorphic-card border-0 shadow-none">


### PR DESCRIPTION
## Summary
- add `points` and `badges` fields to user schema
- update `createOrUpdateUser` to initialize and patch these fields
- award points and badges when creating topics or comments
- display user points and badges on the profile page

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68579db5ddc88327b61887800538cc3c