### PR TITLE
Add image embed support in forum

### DIFF
--- a/convex/forum.ts
+++ b/convex/forum.ts
@@ -129,7 +129,9 @@ export const createTopic = mutation({
     category: v.string(),
     tags: v.array(v.string()),
     hasVideo: v.boolean(),
+    hasImages: v.boolean(),
     videoUrls: v.optional(v.array(v.string())),
+    imageUrls: v.optional(v.array(v.string())),
   },
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
@@ -160,8 +162,10 @@ export const createTopic = mutation({
       isHot: false,
       isPinned: false,
       hasVideo: args.hasVideo,
+      hasImages: args.hasImages,
       tags: args.tags,
       videoUrls: args.videoUrls,
+      imageUrls: args.imageUrls,
       createdAt: now,
       updatedAt: now,
     });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -34,8 +34,10 @@ export default defineSchema({
     isHot: v.boolean(),
     isPinned: v.boolean(),
     hasVideo: v.boolean(),
+    hasImages: v.boolean(),
     tags: v.array(v.string()),
     videoUrls: v.optional(v.array(v.string())),
+    imageUrls: v.optional(v.array(v.string())),
     createdAt: v.number(),
     updatedAt: v.number(),
   })

--- a/src/components/image-embed.tsx
+++ b/src/components/image-embed.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Image as ImageIcon, X } from "lucide-react";
+
+interface ImageEmbedProps {
+  onImageAdd?: (url: string) => void;
+  className?: string;
+}
+
+const ImageEmbed = ({ onImageAdd, className = "" }: ImageEmbedProps) => {
+  const [imageUrl, setImageUrl] = useState("");
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+  const [images, setImages] = useState<string[]>([]);
+
+  const handleAddImage = () => {
+    if (!imageUrl.trim()) return;
+    const url = imageUrl.trim();
+    setImages((prev) => [...prev, url]);
+    onImageAdd?.(url);
+    setImageUrl("");
+    setIsDialogOpen(false);
+  };
+
+  const removeImage = (index: number) => {
+    setImages((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className={`space-y-4 ${className}`}>
+      <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+        <DialogTrigger asChild>
+          <Button className="neumorphic-button bg-transparent text-[#2d3748] font-semibold border-0 shadow-none">
+            <ImageIcon className="h-4 w-4 mr-2" />
+            Tambah Gambar
+          </Button>
+        </DialogTrigger>
+        <DialogContent className="neumorphic-card border-0 shadow-none">
+          <DialogHeader>
+            <DialogTitle className="text-[#2d3748]">Embed Gambar</DialogTitle>
+            <DialogDescription className="text-[#718096]">
+              Masukkan URL gambar untuk menambahkannya ke postingan Anda.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <Input
+              placeholder="https://example.com/image.jpg"
+              value={imageUrl}
+              onChange={(e) => setImageUrl(e.target.value)}
+              className="neumorphic-input border-0"
+            />
+          </div>
+          <DialogFooter>
+            <Button
+              onClick={handleAddImage}
+              className="neumorphic-button bg-transparent text-[#2d3748] font-semibold border-0 shadow-none"
+            >
+              Tambah Gambar
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {images.length > 0 && (
+        <div className="space-y-4">
+          <h4 className="text-sm font-medium text-[#2d3748]">Gambar Ditambahkan:</h4>
+          {images.map((url, index) => (
+            <Card key={index} className="neumorphic-card border-0 shadow-none">
+              <CardContent className="p-4">
+                <div className="flex justify-end mb-2">
+                  <Button
+                    onClick={() => removeImage(index)}
+                    variant="ghost"
+                    size="sm"
+                    className="h-6 w-6 p-0 text-[#718096] hover:text-red-500"
+                  >
+                    <X className="h-3 w-3" />
+                  </Button>
+                </div>
+                <img src={url} alt="embed" className="w-full rounded-lg" />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ImageEmbed;

--- a/src/pages/forum.tsx
+++ b/src/pages/forum.tsx
@@ -21,6 +21,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import VideoEmbed, { VideoData } from "@/components/video-embed";
+import ImageEmbed from "@/components/image-embed";
 import {
   MessageCircle,
   Users,
@@ -53,8 +54,10 @@ interface Topic {
   isHot: boolean;
   isPinned: boolean;
   hasVideo: boolean;
+  hasImages: boolean;
   tags: string[];
   videoUrls?: string[];
+  imageUrls?: string[];
   createdAt: number;
   updatedAt: number;
 }
@@ -88,6 +91,7 @@ export default function Forum() {
     "Diskusi Umum Parfum",
   );
   const [embeddedVideos, setEmbeddedVideos] = useState<VideoData[]>([]);
+  const [embeddedImages, setEmbeddedImages] = useState<string[]>([]);
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [sortBy, setSortBy] = useState<"newest" | "popular" | "unanswered">(
     "newest",
@@ -143,6 +147,10 @@ export default function Forum() {
     setEmbeddedVideos((prev) => [...prev, videoData]);
   };
 
+  const handleImageAdd = (url: string) => {
+    setEmbeddedImages((prev) => [...prev, url]);
+  };
+
   const handleCreateTopic = async () => {
     if (!newTopicTitle.trim() || !newTopicContent.trim()) {
       toast({
@@ -169,13 +177,16 @@ export default function Forum() {
         category: newTopicCategory,
         tags: [],
         hasVideo: embeddedVideos.length > 0,
+        hasImages: embeddedImages.length > 0,
         videoUrls: embeddedVideos.map((v) => v.url),
-      });
+        imageUrls: embeddedImages,
+      } as any);
 
       // Reset form
       setNewTopicTitle("");
       setNewTopicContent("");
       setEmbeddedVideos([]);
+      setEmbeddedImages([]);
       setIsNewTopicOpen(false);
 
       toast({
@@ -555,6 +566,7 @@ export default function Forum() {
                               <span>Media</span>
                             </div>
                             <VideoEmbed onVideoAdd={handleVideoAdd} />
+                            <ImageEmbed onImageAdd={handleImageAdd} />
                           </div>
                         </div>
                         <DialogFooter className="flex gap-2">
@@ -685,6 +697,15 @@ export default function Forum() {
                                   Video
                                 </Badge>
                               )}
+                              {(topic as any).hasImages && (
+                                <Badge
+                                  variant="outline"
+                                  className="text-xs text-teal-600 border-teal-200 flex items-center gap-1"
+                                >
+                                  <Image className="h-3 w-3" />
+                                  Gambar
+                                </Badge>
+                              )}
                               {(topic as any).replies === 0 && (
                                 <Badge
                                   variant="outline"
@@ -799,6 +820,26 @@ export default function Forum() {
                           <p className="text-[#2d3748] leading-relaxed">
                             {selectedTopic.content}
                           </p>
+                          {selectedTopic.imageUrls && selectedTopic.imageUrls.length > 0 && (
+                            <div className="grid grid-cols-2 gap-4 mt-4">
+                              {selectedTopic.imageUrls.map((url, idx) => (
+                                <img key={idx} src={url} className="w-full rounded-lg" />
+                              ))}
+                            </div>
+                          )}
+                          {selectedTopic.videoUrls && selectedTopic.videoUrls.length > 0 && (
+                            <div className="space-y-4 mt-4">
+                              {selectedTopic.videoUrls.map((v, idx) => (
+                                <iframe
+                                  key={idx}
+                                  src={v}
+                                  className="w-full aspect-video rounded-lg"
+                                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                                  allowFullScreen
+                                />
+                              ))}
+                            </div>
+                          )}
                         </div>
 
                         <div className="flex items-center gap-4 pt-4 border-t border-[#e2e8f0]">


### PR DESCRIPTION
## Summary
- allow images to be attached when creating forum topics
- display attached images and videos inside the topic dialog
- show badge when a topic contains images

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68579e020fc083278c3addcb0c721b76