### PR TITLE
Add polling page and navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import Kursus from "./pages/kursus";
 import Database from "./pages/database";
 import Privacy from "./pages/privacy";
 import Terms from "./pages/terms";
+import Polling from "./pages/polling";
 import { Toaster } from "@/components/ui/toaster";
 
 function App() {
@@ -37,6 +38,7 @@ function App() {
           <Route path="/database" element={<Database />} />
           <Route path="/privacy" element={<Privacy />} />
           <Route path="/terms" element={<Terms />} />
+          <Route path="/polling" element={<Polling />} />
         </Routes>
         {import.meta.env.VITE_TEMPO === "true" && useRoutes(routes)}
         <Toaster />

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -93,6 +93,43 @@ export function Navbar() {
                     Kursus
                   </Link>
                   <Link
+                    to="/polling"
+                    className="neumorphic-button-sm inline-flex items-center px-4 py-2 text-sm font-medium text-[#1D1D1F] bg-transparent transition-all duration-200 border-0 shadow-none hover:scale-105 active:scale-95"
+                  >
+                    <svg
+                      className="w-4 h-4 mr-1.5"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M3 3v16a2 2 0 0 0 2 2h16"
+                      />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M7 16h8"
+                      />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M7 11h12"
+                      />
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M7 6h3"
+                      />
+                    </svg>
+                    Polling
+                  </Link>
+                  <Link
                     to="/profile"
                     className="neumorphic-button-sm inline-flex items-center px-4 py-2 text-sm font-medium text-[#1D1D1F] bg-transparent transition-all duration-200 border-0 shadow-none hover:scale-105 active:scale-95"
                   >

--- a/src/pages/polling.tsx
+++ b/src/pages/polling.tsx
@@ -1,0 +1,80 @@
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { BarChart2 } from "lucide-react";
+import { useState } from "react";
+
+export default function Polling() {
+  const [votes, setVotes] = useState<{ [key: string]: number }>({
+    A: 0,
+    B: 0,
+    C: 0,
+  });
+  const [voted, setVoted] = useState<string | null>(null);
+
+  const options = [
+    { id: "A", label: "Pilihan A" },
+    { id: "B", label: "Pilihan B" },
+    { id: "C", label: "Pilihan C" },
+  ];
+
+  const handleVote = (optionId: string) => {
+    if (!voted) {
+      setVotes((prev) => ({ ...prev, [optionId]: prev[optionId] + 1 }));
+      setVoted(optionId);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#F5F5F7] flex flex-col">
+      <Navbar />
+      <main className="flex-grow">
+        <div className="container mx-auto px-4 py-8">
+          <div className="max-w-xl mx-auto space-y-6">
+            <div className="flex justify-center">
+              <div className="neumorphic-card p-4 rounded-2xl">
+                <BarChart2 className="w-12 h-12 text-[#0066CC]" />
+              </div>
+            </div>
+            <h1 className="text-3xl font-bold text-center text-[#1D1D1F]">
+              Polling &amp; Survei
+            </h1>
+            <p className="text-[#86868B] text-center">
+              Fitur ini mempermudah anggota mengumpulkan pendapat atau
+              preferensi dari komunitas. Pengguna cukup membuat pertanyaan singkat
+              dengan pilihan jawaban, lalu anggota lain dapat memilih. Polling
+              yang menarik dapat memicu diskusi lebih lanjut.
+            </p>
+            <Card className="neumorphic-card border-0">
+              <CardHeader>
+                <CardTitle className="text-[#1D1D1F]">Contoh Polling</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <p className="text-[#86868B]">Parfum mana yang paling Anda sukai?</p>
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                  {options.map((opt) => (
+                    <Button
+                      key={opt.id}
+                      onClick={() => handleVote(opt.id)}
+                      disabled={!!voted}
+                      className="neumorphic-button-sm"
+                    >
+                      {opt.label} ({votes[opt.id]})
+                    </Button>
+                  ))}
+                </div>
+                {voted && (
+                  <p className="text-sm text-[#1D1D1F] mt-2">
+                    Anda memilih {options.find((o) => o.id === voted)?.label}
+                  </p>
+                )}
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a new polling page with a simple demo poll
- add navigation link to the new page
- register `/polling` route

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npm run build` *(fails: TS errors in storybook files)*

------
https://chatgpt.com/codex/tasks/task_e_68579df15c7c8327bf5e22a68fe03740