### PR TITLE
Add login and signup pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import Database from "./pages/database";
 import Privacy from "./pages/privacy";
 import Terms from "./pages/terms";
 import Polling from "./pages/polling";
+import Login from "./pages/login";
+import Signup from "./pages/signup";
 import { Toaster } from "@/components/ui/toaster";
 import NotificationListener from "@/components/notification-listener";
 
@@ -25,6 +27,8 @@ function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/signup" element={<Signup />} />
           <Route path="/forum" element={<Forum />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/marketplace" element={<Marketplace />} />

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,4 +1,4 @@
-import { SignInButton, UserButton, useUser } from "@clerk/clerk-react";
+import { UserButton, useUser } from "@clerk/clerk-react";
 import {
   Authenticated,
   Unauthenticated,
@@ -166,15 +166,11 @@ export function Navbar() {
                 </div>
               </Authenticated>
               <Unauthenticated>
-                <SignInButton
-                  mode="modal"
-                  signUpFallbackRedirectUrl="/dashboard"
-                  fallbackRedirectUrl="/dashboard"
-                >
+                <Link to="/login">
                   <Button className="neumorphic-button h-10 px-6 text-sm text-[#2d3748] bg-transparent font-semibold border-0 shadow-none transition-all hover:scale-105 active:scale-95">
                     Masuk
                   </Button>
-                </SignInButton>
+                </Link>
               </Unauthenticated>
             </div>
           ) : (

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -26,6 +26,8 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     <ClerkProvider
       publishableKey={PUBLISHABLE_KEY}
       afterSignOutUrl="/"
+      signInUrl="/login"
+      signUpUrl="/signup"
       appearance={{
         baseTheme: undefined,
         variables: {

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,7 +1,7 @@
 import { Footer } from "@/components/footer";
 import { Navbar } from "@/components/navbar";
 import { Button } from "@/components/ui/button";
-import { SignInButton, useUser } from "@clerk/clerk-react";
+import { useUser } from "@clerk/clerk-react";
 import { Authenticated, Unauthenticated } from "convex/react";
 import {
   ArrowRight,
@@ -13,7 +13,7 @@ import {
   TrendingUp,
   Award,
 } from "lucide-react";
-import { useNavigate } from "react-router";
+import { useNavigate, Link } from "react-router-dom";
 
 const FEATURES = [
   {
@@ -115,16 +115,12 @@ function App() {
                     </Button>
                   </Authenticated>
                   <Unauthenticated>
-                    <SignInButton
-                      mode="modal"
-                      signUpFallbackRedirectUrl="/dashboard"
-                      fallbackRedirectUrl="/dashboard"
-                    >
+                    <Link to="/login">
                       <Button className="neumorphic-button h-14 px-10 text-lg text-[#2d3748] bg-transparent font-semibold border-0 shadow-none transition-all">
                         <ArrowRight className="mr-2 h-5 w-5" />
                         Mulai Sekarang
                       </Button>
-                    </SignInButton>
+                    </Link>
                   </Unauthenticated>
                 </>
               )}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,0 +1,15 @@
+import { SignIn } from "@clerk/clerk-react";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+
+export default function Login() {
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <Navbar />
+      <main className="flex-grow flex items-center justify-center">
+        <SignIn path="/login" routing="path" signUpUrl="/signup" afterSignInUrl="/dashboard" />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,0 +1,15 @@
+import { SignUp } from "@clerk/clerk-react";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+
+export default function Signup() {
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <Navbar />
+      <main className="flex-grow flex items-center justify-center">
+        <SignUp path="/signup" routing="path" signInUrl="/login" afterSignUpUrl="/dashboard" />
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new Login and Signup pages with Clerk components
- add routes for `/login` and `/signup`
- link to login page from navbar and home page
- configure ClerkProvider with signInUrl and signUpUrl

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build` *(fails: missing modules during TypeScript compilation)*

------
https://chatgpt.com/codex/tasks/task_e_6857aa9a34bc8327b930496a154bd81e