### PR TITLE
Fix dark mode neumorphic styles

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -81,6 +81,10 @@
     background: #f0f2f5;
   }
 
+  .dark .neumorphic-bg {
+    background: #1a1a1a;
+  }
+
   /* Neumorphic Card - Raised Effect */
   .neumorphic-card {
     border-radius: 20px;
@@ -92,11 +96,25 @@
     transition: all 0.3s ease;
   }
 
+  .dark .neumorphic-card {
+    background: #2b2b2b;
+    box-shadow:
+      4px 4px 8px rgba(0, 0, 0, 0.4),
+      -4px -4px 8px #333333;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+  }
+
   .neumorphic-card:hover {
     box-shadow:
       6px 6px 12px rgba(163, 177, 198, 0.35),
       -6px -6px 12px #ffffff;
     transform: translateY(-2px);
+  }
+
+  .dark .neumorphic-card:hover {
+    box-shadow:
+      6px 6px 12px rgba(0, 0, 0, 0.45),
+      -6px -6px 12px #333333;
   }
 
   /* Neumorphic Card - Large */
@@ -110,11 +128,25 @@
     transition: all 0.3s ease;
   }
 
+  .dark .neumorphic-card-large {
+    background: #2b2b2b;
+    box-shadow:
+      6px 6px 12px rgba(0, 0, 0, 0.45),
+      -6px -6px 12px #333333;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+  }
+
   .neumorphic-card-large:hover {
     box-shadow:
       8px 8px 16px rgba(163, 177, 198, 0.4),
       -8px -8px 16px #ffffff;
     transform: translateY(-3px);
+  }
+
+  .dark .neumorphic-card-large:hover {
+    box-shadow:
+      8px 8px 16px rgba(0, 0, 0, 0.5),
+      -8px -8px 16px #333333;
   }
 
   /* Neumorphic Card - Inset Effect */
@@ -128,6 +160,14 @@
     transition: all 0.2s ease;
   }
 
+  .dark .neumorphic-card-inset {
+    background: #2b2b2b;
+    box-shadow:
+      inset 4px 4px 8px rgba(0, 0, 0, 0.4),
+      inset -4px -4px 8px #333333;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+  }
+
   /* Neumorphic Button */
   .neumorphic-button {
     border-radius: 20px;
@@ -139,6 +179,14 @@
     transition: all 0.2s ease;
   }
 
+  .dark .neumorphic-button {
+    background: #2b2b2b;
+    box-shadow:
+      4px 4px 8px rgba(0, 0, 0, 0.4),
+      -4px -4px 8px #333333;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+  }
+
   .neumorphic-button:hover {
     box-shadow:
       6px 6px 12px rgba(163, 177, 198, 0.35),
@@ -146,11 +194,23 @@
     transform: translateY(-1px);
   }
 
+  .dark .neumorphic-button:hover {
+    box-shadow:
+      6px 6px 12px rgba(0, 0, 0, 0.45),
+      -6px -6px 12px #333333;
+  }
+
   .neumorphic-button:active {
     box-shadow:
       inset 2px 2px 4px rgba(163, 177, 198, 0.3),
       inset -2px -2px 4px #ffffff;
     transform: translateY(0);
+  }
+
+  .dark .neumorphic-button:active {
+    box-shadow:
+      inset 2px 2px 4px rgba(0, 0, 0, 0.4),
+      inset -2px -2px 4px #333333;
   }
 
   /* Neumorphic Button Small */
@@ -164,6 +224,14 @@
     transition: all 0.2s ease;
   }
 
+  .dark .neumorphic-button-sm {
+    background: #2b2b2b;
+    box-shadow:
+      2px 2px 4px rgba(0, 0, 0, 0.4),
+      -2px -2px 4px #333333;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+  }
+
   .neumorphic-button-sm:hover {
     box-shadow:
       4px 4px 8px rgba(163, 177, 198, 0.35),
@@ -171,11 +239,23 @@
     transform: translateY(-1px);
   }
 
+  .dark .neumorphic-button-sm:hover {
+    box-shadow:
+      4px 4px 8px rgba(0, 0, 0, 0.45),
+      -4px -4px 8px #333333;
+  }
+
   .neumorphic-button-sm:active {
     box-shadow:
       inset 2px 2px 4px rgba(163, 177, 198, 0.3),
       inset -2px -2px 4px #ffffff;
     transform: translateY(0);
+  }
+
+  .dark .neumorphic-button-sm:active {
+    box-shadow:
+      inset 2px 2px 4px rgba(0, 0, 0, 0.4),
+      inset -2px -2px 4px #333333;
   }
 
   /* Neumorphic Input */
@@ -189,11 +269,25 @@
     transition: all 0.2s ease;
   }
 
+  .dark .neumorphic-input {
+    background: #2b2b2b;
+    box-shadow:
+      inset 2px 2px 4px rgba(0, 0, 0, 0.4),
+      inset -2px -2px 4px #333333;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+  }
+
   .neumorphic-input:focus {
     box-shadow:
       inset 4px 4px 8px rgba(163, 177, 198, 0.35),
       inset -4px -4px 8px #ffffff;
     outline: none;
+  }
+
+  .dark .neumorphic-input:focus {
+    box-shadow:
+      inset 4px 4px 8px rgba(0, 0, 0, 0.45),
+      inset -4px -4px 8px #333333;
   }
 
   /* Neumorphic Container */
@@ -206,6 +300,14 @@
     border: 1px solid rgba(0, 0, 0, 0.05);
   }
 
+  .dark .neumorphic-container {
+    background: #2b2b2b;
+    box-shadow:
+      8px 8px 16px rgba(0, 0, 0, 0.45),
+      -8px -8px 16px #333333;
+    border: 1px solid rgba(255, 255, 255, 0.05);
+  }
+
   /* Neumorphic Toast */
   .neumorphic-toast {
     border-radius: 16px;
@@ -214,6 +316,14 @@
       4px 4px 8px rgba(163, 177, 198, 0.3),
       -4px -4px 8px #ffffff;
     border: 1px solid rgba(0, 0, 0, 0.05);
+  }
+
+  .dark .neumorphic-toast {
+    background: #2b2b2b;
+    box-shadow:
+      4px 4px 8px rgba(0, 0, 0, 0.4),
+      -4px -4px 8px #333333;
+    border: 1px solid rgba(255, 255, 255, 0.05);
   }
 
   /* Floating Animation */


### PR DESCRIPTION
## Summary
- add dark variants for neumorphic components so night mode fits the theme

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing packages and types)*

------
https://chatgpt.com/codex/tasks/task_e_6857ad5d829c8327ac6c4fc932867233