### PR TITLE
Implement forum engagement features

### DIFF
--- a/convex/forum.ts
+++ b/convex/forum.ts
@@ -237,6 +237,20 @@ export const createTopic = mutation({
       updatedAt: now,
     });
 
+    // Tambah poin kontribusi pada user
+    const newPoints = (user.contributionPoints ?? 0) + 10;
+    const newBadges = user.badges ? [...user.badges] : [];
+    if (newPoints >= 100 && !newBadges.includes("Kontributor Aktif")) {
+      newBadges.push("Kontributor Aktif");
+    }
+    if (newPoints >= 500 && !newBadges.includes("Master Diskusi")) {
+      newBadges.push("Master Diskusi");
+    }
+    await ctx.db.patch(user._id, {
+      contributionPoints: newPoints,
+      badges: newBadges,
+    });
+
     // Update category count setelah topic dibuat
     await ctx.scheduler.runAfter(
       0,
@@ -361,6 +375,20 @@ export const createComment = mutation({
       likes: 0,
       createdAt: now,
       updatedAt: now,
+    });
+
+    // Tambah poin kontribusi pada user
+    const newPoints = (user.contributionPoints ?? 0) + 2;
+    const newBadges = user.badges ? [...user.badges] : [];
+    if (newPoints >= 100 && !newBadges.includes("Kontributor Aktif")) {
+      newBadges.push("Kontributor Aktif");
+    }
+    if (newPoints >= 500 && !newBadges.includes("Master Diskusi")) {
+      newBadges.push("Master Diskusi");
+    }
+    await ctx.db.patch(user._id, {
+      contributionPoints: newPoints,
+      badges: newBadges,
     });
 
     const topic = await ctx.db.get(args.topicId);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -7,6 +7,8 @@ export default defineSchema({
     email: v.optional(v.string()),
     image: v.optional(v.string()),
     tokenIdentifier: v.string(),
+    contributionPoints: v.number(),
+    badges: v.array(v.string()),
   }).index("by_token", ["tokenIdentifier"]),
 
   categories: defineTable({

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -51,6 +51,13 @@ export const createOrUpdateUser = mutation({
           email: identity.email,
         });
       }
+      // Initialize points/badges if missing
+      if (existingUser.contributionPoints === undefined || existingUser.badges === undefined) {
+        await ctx.db.patch(existingUser._id, {
+          contributionPoints: existingUser.contributionPoints ?? 0,
+          badges: existingUser.badges ?? [],
+        });
+      }
       return existingUser;
     }
 
@@ -59,6 +66,8 @@ export const createOrUpdateUser = mutation({
       name: identity.name,
       email: identity.email,
       tokenIdentifier: identity.subject,
+      contributionPoints: 0,
+      badges: [],
     });
 
     return await ctx.db.get(userId);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import Database from "./pages/database";
 import Privacy from "./pages/privacy";
 import Terms from "./pages/terms";
 import Polling from "./pages/polling";
+import FAQ from "./pages/faq";
 import Login from "./pages/login";
 import Signup from "./pages/signup";
 import { Toaster } from "@/components/ui/toaster";
@@ -44,6 +45,7 @@ function App() {
           <Route path="/privacy" element={<Privacy />} />
           <Route path="/terms" element={<Terms />} />
           <Route path="/polling" element={<Polling />} />
+          <Route path="/faq" element={<FAQ />} />
         </Routes>
         {import.meta.env.VITE_TEMPO === "true" && useRoutes(routes)}
         <NotificationListener />

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -134,6 +134,12 @@ export function Navbar() {
                     Polling
                   </Link>
                   <Link
+                    to="/faq"
+                    className="neumorphic-button-sm inline-flex items-center px-4 py-2 text-sm font-medium text-[#1D1D1F] bg-transparent transition-all duration-200 border-0 shadow-none hover:scale-105 active:scale-95"
+                  >
+                    FAQ
+                  </Link>
+                  <Link
                     to="/profile"
                     className="neumorphic-button-sm inline-flex items-center px-4 py-2 text-sm font-medium text-[#1D1D1F] bg-transparent transition-all duration-200 border-0 shadow-none hover:scale-105 active:scale-95"
                   >
@@ -178,6 +184,7 @@ export function Navbar() {
                       <Link to="/marketplace" className="neumorphic-button-sm w-full text-left">Marketplace</Link>
                       <Link to="/kursus" className="neumorphic-button-sm w-full text-left">Kursus</Link>
                       <Link to="/polling" className="neumorphic-button-sm w-full text-left">Polling</Link>
+                      <Link to="/faq" className="neumorphic-button-sm w-full text-left">FAQ</Link>
                       <Link to="/profile" className="neumorphic-button-sm w-full text-left">Profil</Link>
                       <UserButton
                         afterSignOutUrl="/"
@@ -209,6 +216,7 @@ export function Navbar() {
                     <SheetContent side="left" className="pt-10 flex flex-col space-y-4 neumorphic-bg">
                       <Link to="/login" className="neumorphic-button-sm w-full text-left">Masuk</Link>
                       <Link to="/signup" className="neumorphic-button-sm w-full text-left">Daftar</Link>
+                      <Link to="/faq" className="neumorphic-button-sm w-full text-left">FAQ</Link>
                     </SheetContent>
                   </Sheet>
                 </div>

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -14,6 +14,16 @@ export default function Dashboard() {
     user?.id ? { tokenIdentifier: user.id } : "skip",
   );
 
+  const userTopics = useQuery(
+    api.forum.getTopicsByAuthor,
+    userData ? { authorId: userData._id } : "skip",
+  );
+
+  const userComments = useQuery(
+    api.forum.getCommentsByAuthor,
+    userData ? { authorId: userData._id } : "skip",
+  );
+
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
       <Navbar />
@@ -33,19 +43,17 @@ export default function Dashboard() {
           {/* User Stats Section */}
           <div className="mb-12">
             <UserStats
-              level={5}
-              contributionPoints={1250}
-              postsCount={8}
-              likesReceived={42}
-              commentsCount={15}
+              level={Math.floor((userData?.contributionPoints || 0) / 100) + 1}
+              contributionPoints={userData?.contributionPoints || 0}
+              postsCount={userTopics?.length || 0}
+              likesReceived={
+                userTopics?.reduce((sum, t) => sum + t.likes, 0) || 0
+              }
+              commentsCount={userComments?.length || 0}
               joinDate={new Date(user?.createdAt || "").toLocaleDateString()}
-              badges={[
-                "Reviewer Terpercaya",
-                "Kontributor Aktif",
-                "Parfum Enthusiast",
-              ]}
+              badges={userData?.badges || []}
               weeklyGoal={100}
-              weeklyProgress={75}
+              weeklyProgress={(userData?.contributionPoints || 0) % 100}
             />
           </div>
 

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -1,0 +1,42 @@
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import ProtectedRoute from "@/components/wrappers/ProtectedRoute";
+
+export default function FAQ() {
+  const faqs = [
+    {
+      q: "Apa itu SensasiWangi.id?",
+      a: "SensasiWangi.id adalah komunitas pecinta parfum Indonesia untuk berbagi informasi dan berdiskusi.",
+    },
+    {
+      q: "Bagaimana cara membuat topik baru?",
+      a: "Masuk ke halaman forum lalu klik tombol 'Buat Topik Baru'.",
+    },
+    {
+      q: "Apa manfaat mendapatkan poin?",
+      a: "Poin meningkatkan level akun dan dapat membuka badge khusus.",
+    },
+    {
+      q: "Bagaimana cara menghubungi admin?",
+      a: "Gunakan formulir kontak pada halaman profil atau kirim email ke admin@sensasiwangi.id.",
+    },
+  ];
+
+  return (
+    <ProtectedRoute>
+      <div className="min-h-screen flex flex-col neumorphic-bg">
+        <Navbar />
+        <main className="flex-grow container mx-auto px-4 py-16 space-y-6">
+          <h1 className="text-3xl font-bold text-center mb-8">FAQ</h1>
+          {faqs.map((f, idx) => (
+            <div key={idx} className="neumorphic-card p-6">
+              <h2 className="font-semibold mb-2">{f.q}</h2>
+              <p className="text-sm text-[#4a5568]">{f.a}</p>
+            </div>
+          ))}
+        </main>
+        <Footer />
+      </div>
+    </ProtectedRoute>
+  );
+}

--- a/src/pages/forum.tsx
+++ b/src/pages/forum.tsx
@@ -40,7 +40,10 @@ import {
   Video,
   Image,
   Send,
+  Share,
+  BarChart2,
 } from "lucide-react";
+import { Link } from "react-router-dom";
 import { usePaginatedQuery, useMutation, useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Id } from "../../convex/_generated/dataModel";
@@ -243,6 +246,18 @@ export default function Forum() {
       toast({
         title: liked ? "Topik disukai" : "Batal menyukai topik",
       });
+
+      // Perbarui state topik jika sedang dibuka
+      if (selectedTopic && selectedTopic._id === topicId) {
+        const newLikes = liked
+          ? selectedTopic.likes + 1
+          : Math.max(0, selectedTopic.likes - 1);
+        setSelectedTopic({
+          ...selectedTopic,
+          likes: newLikes,
+          isHot: newLikes >= 10 || selectedTopic.isHot,
+        });
+      }
     } catch (error) {
       console.error("Error toggling like:", error);
       toast({
@@ -553,8 +568,8 @@ export default function Forum() {
                           <Plus className="h-4 w-4 mr-2" />
                           Topik Baru
                         </Button>
-                      </DialogTrigger>
-                      <DialogContent className="neumorphic-card border-0 shadow-none max-w-2xl max-h-[90vh] overflow-y-auto fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50">
+                    </DialogTrigger>
+                    <DialogContent className="neumorphic-card border-0 shadow-none max-w-2xl max-h-[90vh] overflow-y-auto fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-50">
                         <DialogHeader>
                           <DialogTitle className="text-[#2d3748]">
                             Buat Topik Baru
@@ -664,6 +679,13 @@ export default function Forum() {
                         </DialogFooter>
                       </DialogContent>
                     </Dialog>
+                    <Link
+                      to="/polling"
+                      className="neumorphic-button bg-transparent text-[#2d3748] font-semibold hover:text-[#667eea] border-0 shadow-none"
+                    >
+                      <BarChart2 className="h-4 w-4 mr-2" />
+                      Buat Polling
+                    </Link>
                     <div className="flex items-center gap-2 text-sm text-[#718096]">
                       <TrendingUp className="h-4 w-4" />
                       <span>Diskusi trending</span>
@@ -801,6 +823,25 @@ export default function Forum() {
                                   <Heart className="h-4 w-4" />
                                   <span>{topic.likes}</span>
                                 </button>
+                                <button
+                                  onClick={(e) => {
+                                    e.stopPropagation();
+                                    if (navigator.share) {
+                                      navigator.share({
+                                        title: topic.title,
+                                        url: `${window.location.origin}/forum?topic=${topic._id}`,
+                                      });
+                                    } else {
+                                      navigator.clipboard.writeText(
+                                        `${window.location.origin}/forum?topic=${topic._id}`,
+                                      );
+                                      toast({ title: "Link disalin" });
+                                    }
+                                  }}
+                                  className="flex items-center gap-1 hover:text-blue-500 transition-colors"
+                                >
+                                  <Share className="h-4 w-4" />
+                                </button>
                               </div>
                               <div className="flex items-center gap-1">
                                 <Clock className="h-4 w-4" />
@@ -907,6 +948,25 @@ export default function Forum() {
                               <Heart className="h-4 w-4" />
                               <span>{topic.likes}</span>
                             </button>
+                            <button
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                if (navigator.share) {
+                                  navigator.share({
+                                    title: topic.title,
+                                    url: `${window.location.origin}/forum?topic=${topic._id}`,
+                                  });
+                                } else {
+                                  navigator.clipboard.writeText(
+                                    `${window.location.origin}/forum?topic=${topic._id}`,
+                                  );
+                                  toast({ title: "Link disalin" });
+                                }
+                              }}
+                              className="flex items-center gap-1 hover:text-blue-500 transition-colors"
+                            >
+                              <Share className="h-4 w-4" />
+                            </button>
                           </div>
                           <div className="flex items-center gap-1">
                             <Clock className="h-4 w-4" />
@@ -1012,6 +1072,25 @@ export default function Forum() {
                               className={`h-5 w-5 ${userLikedTopics ? "fill-current" : ""}`}
                             />
                             <span>{selectedTopic.likes} Suka</span>
+                          </button>
+                          <button
+                            onClick={() => {
+                              if (navigator.share) {
+                                navigator.share({
+                                  title: selectedTopic.title,
+                                  url: `${window.location.origin}/forum?topic=${selectedTopic._id}`,
+                                });
+                              } else {
+                                navigator.clipboard.writeText(
+                                  `${window.location.origin}/forum?topic=${selectedTopic._id}`,
+                                );
+                                toast({ title: "Link disalin" });
+                              }
+                            }}
+                            className="flex items-center gap-2 px-4 py-2 rounded-lg hover:bg-gray-50 text-[#718096]"
+                          >
+                            <Share className="h-5 w-5" />
+                            <span>Bagikan</span>
                           </button>
 
                           <div className="flex items-center gap-2 text-[#718096]">


### PR DESCRIPTION
## Summary
- extend user schema with contribution points and badges
- reward points and badges when creating topics or comments
- update like handler to refresh state and add share buttons
- show dynamic user stats on dashboard
- add FAQ page and link from navbar
- integrate polling link and share buttons in forum

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_6857b28cd6b083278e5eb1ded981e6c3