### PR TITLE
Redirect from login when already signed in

### DIFF
--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,13 +1,25 @@
-import { SignIn } from "@clerk/clerk-react";
+import { SignIn, useUser } from "@clerk/clerk-react";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
+import { Navigate } from "react-router-dom";
 
 export default function Login() {
+  const { isSignedIn } = useUser();
+
+  if (isSignedIn) {
+    return <Navigate to="/dashboard" />;
+  }
+
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
       <Navbar />
       <main className="flex-grow flex items-center justify-center">
-        <SignIn path="/login" routing="path" signUpUrl="/signup" afterSignInUrl="/dashboard" />
+        <SignIn
+          path="/login"
+          routing="path"
+          signUpUrl="/signup"
+          afterSignInUrl="/dashboard"
+        />
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- improve login UX by redirecting already signed-in users to the dashboard

## Testing
- `npm run lint` *(fails: couldn't find an ESLint config)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6857dd60633c8327b6b2ef89a141feb6