### PR TITLE
Add order detail page and My Shop

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,8 @@ import Marketplace from "./pages/marketplace";
 import MarketplaceSell from "./pages/marketplace-sell";
 import MarketplaceSambat from "./pages/marketplace-sambat";
 import MarketplaceSambatCreate from "./pages/marketplace-sambat-create";
+import MyShop from "./pages/my-shop";
+import OrderDetail from "./pages/order-detail";
 import Admin from "./pages/admin";
 import Kursus from "./pages/kursus";
 import Database from "./pages/database";
@@ -30,6 +32,7 @@ function App() {
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/dashboard/my-shop" element={<MyShop />} />
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/forum" element={<Forum />} />
@@ -50,6 +53,7 @@ function App() {
           <Route path="/terms" element={<Terms />} />
           <Route path="/polling" element={<Polling />} />
           <Route path="/faq" element={<FAQ />} />
+          <Route path="/order/:orderId" element={<OrderDetail />} />
           <Route path="/order/:orderId/review" element={<OrderReviewPage />} />
         </Routes>
         {import.meta.env.VITE_TEMPO === "true" && useRoutes(routes)}

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -11,7 +11,7 @@ import { api } from "../../convex/_generated/api";
 import { Button } from "./ui/button";
 import { LanguageToggle } from "./language-toggle";
 import { Sheet, SheetTrigger, SheetContent } from "./ui/sheet";
-import { Menu } from "lucide-react";
+import { Menu, Store } from "lucide-react";
 
 export function Navbar() {
   const { user, isLoaded } = useUser();
@@ -94,13 +94,20 @@ export function Navbar() {
                         strokeWidth={1.5}
                         d="M16 11V7a4 4 0 00-8 0v4M8 11v6h8v-6M8 11H6a2 2 0 00-2 2v6a2 2 0 002 2h12a2 2 0 002-2v-6a2 2 0 00-2-2h-2"
                       />
-                    </svg>
-                    Marketplace
-                  </Link>
-                  <Link
-                    to="/kursus"
-                    className="neumorphic-button-sm inline-flex items-center px-4 py-2 text-sm font-medium text-[#1D1D1F] bg-transparent transition-all duration-200 border-0 shadow-none hover:scale-105 active:scale-95"
-                  >
+                  </svg>
+                  Marketplace
+                </Link>
+                <Link
+                  to="/dashboard/my-shop"
+                  className="neumorphic-button-sm inline-flex items-center px-4 py-2 text-sm font-medium text-[#1D1D1F] bg-transparent transition-all duration-200 border-0 shadow-none hover:scale-105 active:scale-95"
+                >
+                  <Store className="w-4 h-4 mr-1.5" />
+                  My Shop
+                </Link>
+                <Link
+                  to="/kursus"
+                  className="neumorphic-button-sm inline-flex items-center px-4 py-2 text-sm font-medium text-[#1D1D1F] bg-transparent transition-all duration-200 border-0 shadow-none hover:scale-105 active:scale-95"
+                >
                     <svg
                       className="w-4 h-4 mr-1.5"
                       fill="none"
@@ -203,6 +210,7 @@ export function Navbar() {
                       <Link to="/dashboard" className="neumorphic-button-sm w-full text-left">Dashboard</Link>
                       <Link to="/forum" className="neumorphic-button-sm w-full text-left">Forum</Link>
                       <Link to="/marketplace" className="neumorphic-button-sm w-full text-left">Marketplace</Link>
+                      <Link to="/dashboard/my-shop" className="neumorphic-button-sm w-full text-left">My Shop</Link>
                       <Link to="/kursus" className="neumorphic-button-sm w-full text-left">Kursus</Link>
                       <Link to="/polling" className="neumorphic-button-sm w-full text-left">Polling</Link>
                       <Link to="/faq" className="neumorphic-button-sm w-full text-left">FAQ</Link>

--- a/src/pages/my-shop.tsx
+++ b/src/pages/my-shop.tsx
@@ -1,0 +1,46 @@
+import { useUser } from "@clerk/clerk-react";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { Link } from "react-router-dom";
+
+export default function MyShop() {
+  const { user } = useUser();
+  const userData = useQuery(
+    api.users.getUserByToken,
+    user?.id ? { tokenIdentifier: user.id } : "skip",
+  );
+  const orders = useQuery(
+    api.marketplace.getOrdersByUser,
+    userData ? { userId: userData._id, type: "seller" } : "skip",
+  );
+
+  if (orders === undefined) return <div>Loading...</div>;
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <Navbar />
+      <main className="flex-grow container mx-auto px-4 py-16">
+        <h1 className="text-2xl font-semibold mb-6">Pesanan Toko Saya</h1>
+        {orders.length === 0 ? (
+          <p>Tidak ada pesanan.</p>
+        ) : (
+          <div className="space-y-4">
+            {orders.map((o) => (
+              <Link
+                key={o._id}
+                to={`/order/${o._id}`}
+                className="block neumorphic-card p-4 hover:bg-[#f5f5f7]"
+              >
+                <div className="font-semibold">{o.productTitle}</div>
+                <div className="text-sm text-[#86868B]">Pembeli: {o.buyerName}</div>
+                <div className="text-sm">Status: {o.orderStatus}</div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/order-detail.tsx
+++ b/src/pages/order-detail.tsx
@@ -1,0 +1,55 @@
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { useParams } from "react-router-dom";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+
+export default function OrderDetail() {
+  const { orderId } = useParams();
+  const order = useQuery(
+    api.marketplace.getOrderById,
+    orderId ? { orderId: orderId as any } : "skip",
+  );
+
+  if (order === undefined) return <div>Loading...</div>;
+  if (order === null) return <div>Order tidak ditemukan</div>;
+
+  const steps = ["pending", "confirmed", "shipped", "delivered"] as const;
+  const currentIndex = steps.indexOf(order.orderStatus as any);
+
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <Navbar />
+      <main className="flex-grow container mx-auto px-4 py-16 space-y-6">
+        <h1 className="text-2xl font-semibold">Detail Pesanan</h1>
+        <div className="neumorphic-card p-6 space-y-2">
+          <div className="font-semibold">{order.productTitle}</div>
+          <div>Pembeli: {order.buyerName}</div>
+          <div>Metode Pembayaran: {order.paymentMethod}</div>
+        </div>
+        <div className="neumorphic-card p-6">
+          <h2 className="font-semibold mb-2">Riwayat Status</h2>
+          <ol className="list-decimal pl-4 space-y-1">
+            {steps.map((status, idx) => (
+              <li
+                key={status}
+                className={idx <= currentIndex ? "text-[#1D1D1F]" : "text-[#86868B]"}
+              >
+                {status}
+              </li>
+            ))}
+          </ol>
+        </div>
+        <div className="neumorphic-card p-6">
+          <h2 className="font-semibold mb-2">Bukti Bayar</h2>
+          {order.paymentStatus === "paid" ? (
+            <p>Virtual Account: {order.virtualAccountNumber}</p>
+          ) : (
+            <p>Belum dibayar</p>
+          )}
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add My Shop page for sellers
- list orders and link to order detail
- create Order Detail page with status timeline and payment info
- update routing for new pages
- add My Shop navigation links

## Testing
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68580012cf4c8327b22f90631cfc4535