### PR TITLE
Add Sambat product detail page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import MarketplaceSell from "./pages/marketplace-sell";
 import MyShop from "./pages/my-shop";
 import MarketplaceSambat from "./pages/marketplace-sambat";
 import MarketplaceSambatCreate from "./pages/marketplace-sambat-create";
+import MarketplaceSambatDetail from "./pages/marketplace-sambat-detail";
 import MarketplaceProduct from "./pages/marketplace-product";
 import Admin from "./pages/admin";
 import Kursus from "./pages/kursus";
@@ -47,6 +48,10 @@ function App() {
           <Route path="/marketplace/sell" element={<MarketplaceSell />} />
           <Route path="/marketplace/my-shop" element={<MyShop />} />
           <Route path="/marketplace/sambat" element={<MarketplaceSambat />} />
+          <Route
+            path="/marketplace/sambat/:id"
+            element={<MarketplaceSambatDetail />}
+          />
           <Route
             path="/marketplace/sambat/create"
             element={<MarketplaceSambatCreate />}

--- a/src/pages/marketplace-sambat-detail.tsx
+++ b/src/pages/marketplace-sambat-detail.tsx
@@ -1,0 +1,105 @@
+import { useParams } from "react-router-dom";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { Progress } from "@/components/ui/progress";
+
+export default function MarketplaceSambatDetail() {
+  const { id } = useParams();
+  const product = useQuery(
+    api.marketplace.getSambatProductById,
+    id ? { sambatProductId: id as any } : "skip",
+  );
+  const enrollments = useQuery(
+    api.marketplace.getSambatEnrollments,
+    id ? { sambatProductId: id as any } : "skip",
+  );
+
+  if (product === undefined) return <div>Loading...</div>;
+  if (product === null) return <div>Produk sambatan tidak ditemukan</div>;
+
+  const progress =
+    (product.currentParticipants / product.maxParticipants) * 100;
+
+  const formatPrice = (price: number) =>
+    new Intl.NumberFormat("id-ID", {
+      style: "currency",
+      currency: "IDR",
+      minimumFractionDigits: 0,
+    }).format(price);
+
+  const formatDate = (timestamp: number) =>
+    new Date(timestamp).toLocaleDateString("id-ID", {
+      day: "numeric",
+      month: "long",
+      year: "numeric",
+    });
+
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <Navbar />
+      <main className="flex-grow container mx-auto px-4 py-8 space-y-8">
+        <div className="flex flex-col md:flex-row gap-8">
+          <img
+            src={
+              product.images[0] ||
+              "https://images.unsplash.com/photo-1541643600914-78b084683601?w=600&q=80"
+            }
+            alt={product.title}
+            className="w-full md:w-1/2 rounded-3xl object-cover"
+          />
+          <div className="flex-1 space-y-4">
+            <h1 className="text-2xl font-semibold text-[#2d3748]">
+              {product.title}
+            </h1>
+            <p className="text-[#718096]">{product.brand}</p>
+            <div className="space-y-1">
+              <p className="font-bold text-[#2d3748]">
+                {formatPrice(product.pricePerPortion)} per {product.portionSize}
+              </p>
+              <p className="text-sm text-[#718096] line-through">
+                {formatPrice(product.originalPrice)}
+              </p>
+            </div>
+            <div className="space-y-2">
+              <div className="flex justify-between text-sm">
+                <span className="text-[#718096]">Progress</span>
+                <span className="text-[#2d3748] font-medium">
+                  {product.currentParticipants}/{product.maxParticipants} porsi
+                </span>
+              </div>
+              <Progress value={progress} className="h-2" />
+            </div>
+            <div className="text-sm text-[#718096]">
+              Lokasi: {product.location}
+            </div>
+            <div className="text-sm text-[#718096]">
+              Deadline: {formatDate(product.deadline)}
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <h2 className="text-xl font-semibold text-[#2d3748] mb-4">Peserta</h2>
+          <div className="space-y-2">
+            {enrollments?.map((e) => (
+              <div
+                key={e._id}
+                className="neumorphic-card p-4 flex items-center justify-between"
+              >
+                <span>{e.userName}</span>
+                <span>{e.portionsRequested} porsi</span>
+                <span className="text-sm text-[#718096]">{e.paymentStatus}</span>
+              </div>
+            ))}
+            {enrollments && enrollments.length === 0 && (
+              <p className="text-[#718096]">Belum ada peserta</p>
+            )}
+          </div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/marketplace-sambat.tsx
+++ b/src/pages/marketplace-sambat.tsx
@@ -85,7 +85,7 @@ function SambatProductCard({ product }: { product: any }) {
 
   const handleCardClick = () => {
     incrementViews({ sambatProductId: product._id });
-    // Navigate to detail page (will be created later)
+    navigate(`/marketplace/sambat/${product._id}`);
   };
 
   const handleLike = (e: React.MouseEvent) => {


### PR DESCRIPTION
## Summary
- implement MarketplaceSambatDetail page
- show sambat participant data
- add new route for the detail page
- link Sambat cards to the detail page

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build-no-errors` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68580a92d7148327a49ae40611af1524