### PR TITLE
Add order detail page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import FAQ from "./pages/faq";
 import Login from "./pages/login";
 import Signup from "./pages/signup";
 import OrderReviewPage from "./pages/order-review";
+import OrderDetail from "./pages/order-detail";
 import MarketplaceCheckout from "./pages/marketplace-checkout";
 import { Toaster } from "@/components/ui/toaster";
 import NotificationListener from "@/components/notification-listener";
@@ -57,6 +58,10 @@ function App() {
             element={<MarketplaceSambatCreate />}
           />
           <Route path="/marketplace/checkout" element={<MarketplaceCheckout />} />
+          <Route
+            path="/marketplace/order/:orderId"
+            element={<OrderDetail />}
+          />
           <Route path="/admin" element={<Admin />} />
           <Route path="/kursus" element={<Kursus />} />
           <Route path="/database" element={<Database />} />

--- a/src/pages/my-shop.tsx
+++ b/src/pages/my-shop.tsx
@@ -92,6 +92,12 @@ function MyShopContent() {
                       <p className="text-sm">Status: {o.orderStatus}</p>
                       <p className="text-sm">Pembayaran: {o.paymentStatus}</p>
                     </div>
+                    <Button
+                      size="sm"
+                      onClick={() => navigate(`/marketplace/order/${o._id}`)}
+                    >
+                      Lihat Detail
+                    </Button>
                   </CardContent>
                 </Card>
               ))}

--- a/src/pages/order-detail.tsx
+++ b/src/pages/order-detail.tsx
@@ -1,0 +1,77 @@
+import { useParams } from "react-router-dom";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function OrderDetail() {
+  const { orderId } = useParams();
+  const order = useQuery(
+    api.marketplace.getOrderById,
+    orderId ? { orderId: orderId as any } : "skip",
+  );
+
+  if (order === undefined) return <div>Loading...</div>;
+  if (order === null) return <div>Order tidak ditemukan</div>;
+
+  const formatPrice = (price: number) =>
+    new Intl.NumberFormat("id-ID", {
+      style: "currency",
+      currency: "IDR",
+      minimumFractionDigits: 0,
+    }).format(price);
+
+  const shipping: any = order.shippingAddress || {};
+
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <Navbar />
+      <main className="flex-grow container mx-auto px-4 py-16 space-y-6">
+        <h1 className="text-2xl font-semibold mb-4">Detail Order</h1>
+        <Card className="neumorphic-card border-0">
+          <CardHeader>
+            <CardTitle>{order.productTitle}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm">
+            <p>Status Order: {order.orderStatus}</p>
+            <p>Status Pembayaran: {order.paymentStatus}</p>
+            <p>Total: {formatPrice(order.totalAmount)}</p>
+          </CardContent>
+        </Card>
+
+        <Card className="neumorphic-card border-0">
+          <CardHeader>
+            <CardTitle>Detail Pengiriman</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1 text-sm">
+            <p>Nama: {shipping.name}</p>
+            <p>Telepon: {shipping.phone}</p>
+            <p>Alamat: {shipping.address}</p>
+            <p>Kota: {shipping.city}</p>
+            <p>Provinsi: {shipping.province}</p>
+            <p>Kode Pos: {shipping.postalCode}</p>
+            <p>Metode Pengiriman: {order.shippingMethod}</p>
+            {order.trackingNumber && <p>Resi: {order.trackingNumber}</p>}
+          </CardContent>
+        </Card>
+
+        {order.paymentProofUrl && (
+          <Card className="neumorphic-card border-0">
+            <CardHeader>
+              <CardTitle>Bukti Pembayaran</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <img
+                src={order.paymentProofUrl}
+                alt="Bukti Pembayaran"
+                className="max-w-xs rounded"
+              />
+            </CardContent>
+          </Card>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new OrderDetail page to display order and shipping info
- link to OrderDetail in MyShop order listings
- register `/marketplace/order/:orderId` route in App

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: missing module type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68580bd4d3cc8327906dd05faa5523aa