### PR TITLE
Add admin order management

### DIFF
--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -1,4 +1,6 @@
 import { useState } from "react";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "../../convex/_generated/api";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import {
@@ -34,6 +36,10 @@ import {
 
 export default function Admin() {
   const [activeTab, setActiveTab] = useState("overview");
+
+  const pendingOrders = useQuery(api.marketplace.getPendingOrders);
+  const verifyPayment = useMutation(api.marketplace.verifyOrderPayment);
+  const updateStatus = useMutation(api.marketplace.updateOrderStatus);
 
   // Mock data untuk demonstrasi
   const stats = {
@@ -145,6 +151,13 @@ export default function Admin() {
             >
               <MessageSquare className="w-4 h-4 mr-2" />
               Masukan
+            </TabsTrigger>
+            <TabsTrigger
+              value="orders"
+              className="neumorphic-button-sm data-[state=active]:bg-white data-[state=active]:shadow-inner text-[#1D1D1F]"
+            >
+              <CheckCircle className="w-4 h-4 mr-2" />
+              Pesanan
             </TabsTrigger>
           </TabsList>
 
@@ -817,6 +830,97 @@ export default function Admin() {
                         </div>
                       </TableCell>
                     </TableRow>
+                  </TableBody>
+                </Table>
+              </CardContent>
+            </Card>
+          </TabsContent>
+
+          <TabsContent value="orders" className="space-y-6">
+            <Card className="neumorphic-card border-0">
+              <CardHeader>
+                <CardTitle className="text-[#1D1D1F]">Manajemen Pesanan</CardTitle>
+                <CardDescription className="text-[#86868B]">
+                  Verifikasi pembayaran dan update status pengiriman
+                </CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="text-[#1D1D1F]">Produk</TableHead>
+                      <TableHead className="text-[#1D1D1F]">Pembeli</TableHead>
+                      <TableHead className="text-[#1D1D1F]">Pembayaran</TableHead>
+                      <TableHead className="text-[#1D1D1F]">Status</TableHead>
+                      <TableHead className="text-[#1D1D1F]">Aksi</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {!pendingOrders
+                      ? null
+                      : pendingOrders.map((order: any) => (
+                          <TableRow key={order._id}>
+                            <TableCell className="text-[#1D1D1F]">
+                              {order.productTitle}
+                            </TableCell>
+                            <TableCell className="text-[#86868B]">
+                              {order.buyerName}
+                            </TableCell>
+                            <TableCell className="text-[#86868B]">
+                              {order.paymentStatus}
+                            </TableCell>
+                            <TableCell className="text-[#86868B]">
+                              {order.orderStatus}
+                            </TableCell>
+                            <TableCell>
+                              <div className="flex space-x-2">
+                                {order.paymentStatus === "pending" && (
+                                  <Button
+                                    size="sm"
+                                    className="neumorphic-button-sm h-8 px-3 text-xs"
+                                    onClick={async () => {
+                                      await verifyPayment({ orderId: order._id });
+                                    }}
+                                  >
+                                    Verifikasi
+                                  </Button>
+                                )}
+                                {order.orderStatus === "confirmed" && (
+                                  <Button
+                                    size="sm"
+                                    className="neumorphic-button-sm h-8 px-3 text-xs"
+                                    onClick={async () => {
+                                      const resi = window.prompt("Nomor Resi");
+                                      if (resi) {
+                                        await updateStatus({
+                                          orderId: order._id,
+                                          status: "shipped",
+                                          trackingNumber: resi,
+                                        });
+                                      }
+                                    }}
+                                  >
+                                    Kirim
+                                  </Button>
+                                )}
+                                {order.orderStatus === "shipped" && (
+                                  <Button
+                                    size="sm"
+                                    className="neumorphic-button-sm h-8 px-3 text-xs"
+                                    onClick={async () => {
+                                      await updateStatus({
+                                        orderId: order._id,
+                                        status: "delivered",
+                                      });
+                                    }}
+                                  >
+                                    Selesai
+                                  </Button>
+                                )}
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        ))}
                   </TableBody>
                 </Table>
               </CardContent>


### PR DESCRIPTION
## Summary
- enable fetching and management of marketplace orders
- admin panel can verify payments and update order status
- notify users on status changes

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_68580cb220a883279841bdc9097413e5