### PR TITLE
Add verification workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ Ensure the `CONVEX_URL` environment variable points to your Convex deployment.
 
 Available endpoints:
 
-- `GET /api/brands` – Indonesian brands
-- `GET /api/perfumers` – Indonesian perfumers
-- `GET /api/fragrances` – Indonesian fragrances
+- `GET /api/brands` – Indonesian brands (only verified)
+- `GET /api/perfumers` – Indonesian perfumers (only verified)
+- `GET /api/fragrances` – Indonesian fragrances (only verified)
 - `GET /api/stats` – Overall database statistics
+
+Use the optional `verified=true` query parameter to explicitly fetch verified
+records for marketplace or course integrations.

--- a/convex/marketplace.ts
+++ b/convex/marketplace.ts
@@ -1300,7 +1300,8 @@ export const getIndonesianBrands = query({
     let query: any = ctx.db
       .query("brands")
       .withIndex("by_country", (q) => q.eq("country", "Indonesia"))
-      .filter((q) => q.eq(q.field("isActive"), true));
+      .filter((q) => q.eq(q.field("isActive"), true))
+      .filter((q) => q.eq(q.field("verificationStatus"), "approved"));
 
     // Sorting
     if (args.sortBy === "rating") {
@@ -1309,35 +1310,40 @@ export const getIndonesianBrands = query({
         .withIndex("by_rating")
         .order("desc")
         .filter((q) => q.eq(q.field("country"), "Indonesia"))
-        .filter((q) => q.eq(q.field("isActive"), true));
+        .filter((q) => q.eq(q.field("isActive"), true))
+        .filter((q) => q.eq(q.field("verificationStatus"), "approved"));
     } else if (args.sortBy === "popular") {
       query = ctx.db
         .query("brands")
         .withIndex("by_views")
         .order("desc")
         .filter((q) => q.eq(q.field("country"), "Indonesia"))
-        .filter((q) => q.eq(q.field("isActive"), true));
+        .filter((q) => q.eq(q.field("isActive"), true))
+        .filter((q) => q.eq(q.field("verificationStatus"), "approved"));
     } else if (args.sortBy === "liked") {
       query = ctx.db
         .query("brands")
         .withIndex("by_likes")
         .order("desc")
         .filter((q) => q.eq(q.field("country"), "Indonesia"))
-        .filter((q) => q.eq(q.field("isActive"), true));
+        .filter((q) => q.eq(q.field("isActive"), true))
+        .filter((q) => q.eq(q.field("verificationStatus"), "approved"));
     } else if (args.sortBy === "name") {
       query = ctx.db
         .query("brands")
         .withIndex("by_created_at")
         .order("asc")
         .filter((q) => q.eq(q.field("country"), "Indonesia"))
-        .filter((q) => q.eq(q.field("isActive"), true));
+        .filter((q) => q.eq(q.field("isActive"), true))
+        .filter((q) => q.eq(q.field("verificationStatus"), "approved"));
     } else {
       query = ctx.db
         .query("brands")
         .withIndex("by_created_at")
         .order("desc")
         .filter((q) => q.eq(q.field("country"), "Indonesia"))
-        .filter((q) => q.eq(q.field("isActive"), true));
+        .filter((q) => q.eq(q.field("isActive"), true))
+        .filter((q) => q.eq(q.field("verificationStatus"), "approved"));
     }
 
     const brands = await query.paginate(args.paginationOpts);
@@ -1391,7 +1397,8 @@ export const getIndonesianPerfumers = query({
     let query: any = ctx.db
       .query("perfumers")
       .withIndex("by_nationality", (q) => q.eq("nationality", "Indonesia"))
-      .filter((q) => q.eq(q.field("isActive"), true));
+      .filter((q) => q.eq(q.field("isActive"), true))
+      .filter((q) => q.eq(q.field("verificationStatus"), "approved"));
 
     // Sorting
     if (args.sortBy === "rating") {
@@ -1400,21 +1407,24 @@ export const getIndonesianPerfumers = query({
         .withIndex("by_rating")
         .order("desc")
         .filter((q) => q.eq(q.field("nationality"), "Indonesia"))
-        .filter((q) => q.eq(q.field("isActive"), true));
+        .filter((q) => q.eq(q.field("isActive"), true))
+        .filter((q) => q.eq(q.field("verificationStatus"), "approved"));
     } else if (args.sortBy === "experience") {
       query = ctx.db
         .query("perfumers")
         .withIndex("by_experience")
         .order("desc")
         .filter((q) => q.eq(q.field("nationality"), "Indonesia"))
-        .filter((q) => q.eq(q.field("isActive"), true));
+        .filter((q) => q.eq(q.field("isActive"), true))
+        .filter((q) => q.eq(q.field("verificationStatus"), "approved"));
     } else {
       query = ctx.db
         .query("perfumers")
         .withIndex("by_created_at")
         .order("desc")
         .filter((q) => q.eq(q.field("nationality"), "Indonesia"))
-        .filter((q) => q.eq(q.field("isActive"), true));
+        .filter((q) => q.eq(q.field("isActive"), true))
+        .filter((q) => q.eq(q.field("verificationStatus"), "approved"));
     }
 
     const perfumers = await query.paginate(args.paginationOpts);
@@ -1478,7 +1488,9 @@ export const getIndonesianFragrances = query({
     searchQuery: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    let query: any = ctx.db.query("fragrances");
+    let query: any = ctx.db
+      .query("fragrances")
+      .filter((q) => q.eq(q.field("verificationStatus"), "approved"));
 
     // Filter by brand first if specified
     if (args.brandId) {
@@ -1506,6 +1518,7 @@ export const getIndonesianFragrances = query({
     const indonesianBrands = await ctx.db
       .query("brands")
       .withIndex("by_country", (q) => q.eq("country", "Indonesia"))
+      .filter((q) => q.eq(q.field("verificationStatus"), "approved"))
       .collect();
     const indonesianBrandIds = new Set(indonesianBrands.map((b) => b._id));
 
@@ -1567,16 +1580,21 @@ export const getDatabaseStats = query({
       .query("brands")
       .withIndex("by_country", (q) => q.eq("country", "Indonesia"))
       .filter((q) => q.eq(q.field("isActive"), true))
+      .filter((q) => q.eq(q.field("verificationStatus"), "approved"))
       .collect();
 
     const indonesianPerfumers = await ctx.db
       .query("perfumers")
       .withIndex("by_nationality", (q) => q.eq("nationality", "Indonesia"))
       .filter((q) => q.eq(q.field("isActive"), true))
+      .filter((q) => q.eq(q.field("verificationStatus"), "approved"))
       .collect();
 
     const indonesianBrandIds = new Set(indonesianBrands.map((b) => b._id));
-    const allFragrances = await ctx.db.query("fragrances").collect();
+    const allFragrances = await ctx.db
+      .query("fragrances")
+      .filter((q) => q.eq(q.field("verificationStatus"), "approved"))
+      .collect();
     const indonesianFragrances = allFragrances.filter((f) =>
       indonesianBrandIds.has(f.brandId),
     );
@@ -1868,6 +1886,44 @@ export const initializeSampleData = mutation({
       perfumers: samplePerfumers.length,
       fragrances: sampleFragrances.length,
     };
+  },
+});
+
+// ===== VERIFICATION =====
+
+export const submitVerificationRequest = mutation({
+  args: { itemType: v.string(), itemId: v.string() },
+  handler: async (ctx, args) => {
+    const table =
+      args.itemType === "brand"
+        ? "brands"
+        : args.itemType === "perfumer"
+        ? "perfumers"
+        : args.itemType === "fragrance"
+        ? "fragrances"
+        : null;
+    if (!table) throw new Error("Invalid item type");
+    await ctx.db.patch(args.itemId as any, {
+      verificationStatus: "pending",
+    });
+  },
+});
+
+export const moderateVerificationRequest = mutation({
+  args: { itemType: v.string(), itemId: v.string(), approve: v.boolean() },
+  handler: async (ctx, args) => {
+    const table =
+      args.itemType === "brand"
+        ? "brands"
+        : args.itemType === "perfumer"
+        ? "perfumers"
+        : args.itemType === "fragrance"
+        ? "fragrances"
+        : null;
+    if (!table) throw new Error("Invalid item type");
+    await ctx.db.patch(args.itemId as any, {
+      verificationStatus: args.approve ? "approved" : "rejected",
+    });
   },
 });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -319,6 +319,7 @@ export default defineSchema({
     foundedYear: v.optional(v.number()),
     category: v.string(), // "Local", "Artisan", "Commercial", "Niche"
     isActive: v.boolean(),
+    verificationStatus: v.string(), // "unverified", "pending", "approved", "rejected"
     totalProducts: v.number(),
     rating: v.number(),
     totalReviews: v.number(),
@@ -356,6 +357,7 @@ export default defineSchema({
       }),
     ),
     isActive: v.boolean(),
+    verificationStatus: v.string(),
     totalCreations: v.number(),
     rating: v.number(),
     totalReviews: v.number(),
@@ -390,6 +392,7 @@ export default defineSchema({
     price: v.optional(v.number()),
     sizes: v.array(v.string()), // ["30ml", "50ml", "100ml"]
     isDiscontinued: v.boolean(),
+    verificationStatus: v.string(),
     rating: v.number(),
     totalReviews: v.number(),
     totalLikes: v.number(),

--- a/src/pages/database.tsx
+++ b/src/pages/database.tsx
@@ -26,6 +26,8 @@ import {
   Globe,
 } from "lucide-react";
 import { useState } from "react";
+import { useUser } from "@clerk/clerk-react";
+import { useToast } from "@/components/ui/use-toast";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { useTranslation } from "react-i18next";
@@ -81,6 +83,39 @@ export default function Database() {
   const initializeSampleData = useMutation(
     api.marketplace.initializeSampleData,
   );
+  const requestVerification = useMutation(
+    api.marketplace.submitVerificationRequest,
+  );
+  const createSuggestion = useMutation(api.marketplace.createSuggestion);
+  const { user } = useUser();
+  const { toast } = useToast();
+
+  const handleVerify = async (type: string, id: string) => {
+    try {
+      await requestVerification({ itemType: type, itemId: id });
+      toast({ title: "Permintaan terkirim" });
+    } catch (_) {
+      toast({ title: "Error", variant: "destructive" });
+    }
+  };
+
+  const handleProposeEdit = async (type: string, item: any) => {
+    const message = prompt("Detail perubahan yang diusulkan?");
+    if (!message) return;
+    try {
+      await createSuggestion({
+        name: user?.fullName || "Anonymous",
+        email:
+          (user?.primaryEmailAddress as any)?.emailAddress || "unknown@user",
+        type: "suggestion",
+        subject: `Edit proposal for ${type} ${item.name}`,
+        message,
+      });
+      toast({ title: "Usulan dikirim" });
+    } catch (_) {
+      toast({ title: "Gagal", variant: "destructive" });
+    }
+  };
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
@@ -283,6 +318,41 @@ export default function Database() {
                               </div>
                             )}
                           </div>
+                          <div className="flex flex-col items-end gap-2">
+                            <Badge
+                              className={
+                                brand.verificationStatus === "approved"
+                                  ? "bg-green-100 text-green-800"
+                                  : brand.verificationStatus === "pending"
+                                  ? "bg-yellow-100 text-yellow-800"
+                                  : brand.verificationStatus === "rejected"
+                                  ? "bg-red-100 text-red-800"
+                                  : "bg-gray-100 text-gray-800"
+                              }
+                            >
+                              {brand.verificationStatus}
+                            </Badge>
+                            {user && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="neumorphic-button-sm h-7 px-2 text-xs"
+                                onClick={() => handleProposeEdit("brand", brand)}
+                              >
+                                Edit
+                              </Button>
+                            )}
+                            {user && brand.verificationStatus === "unverified" && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="neumorphic-button-sm h-7 px-2 text-xs"
+                                onClick={() => handleVerify("brand", brand._id)}
+                              >
+                                Verify
+                              </Button>
+                            )}
+                          </div>
                         </div>
                       </CardHeader>
                       <CardContent className="pt-0">
@@ -406,6 +476,41 @@ export default function Database() {
                               {perfumer.experience}
                             </Badge>
                           </div>
+                          <div className="flex flex-col items-end gap-2">
+                            <Badge
+                              className={
+                                perfumer.verificationStatus === "approved"
+                                  ? "bg-green-100 text-green-800"
+                                  : perfumer.verificationStatus === "pending"
+                                  ? "bg-yellow-100 text-yellow-800"
+                                  : perfumer.verificationStatus === "rejected"
+                                  ? "bg-red-100 text-red-800"
+                                  : "bg-gray-100 text-gray-800"
+                              }
+                            >
+                              {perfumer.verificationStatus}
+                            </Badge>
+                            {user && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="neumorphic-button-sm h-7 px-2 text-xs"
+                                onClick={() => handleProposeEdit("perfumer", perfumer)}
+                              >
+                                Edit
+                              </Button>
+                            )}
+                            {user && perfumer.verificationStatus === "unverified" && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="neumorphic-button-sm h-7 px-2 text-xs"
+                                onClick={() => handleVerify("perfumer", perfumer._id)}
+                              >
+                                Verify
+                              </Button>
+                            )}
+                          </div>
                         </div>
                       </CardHeader>
                       <CardContent className="pt-0">
@@ -511,7 +616,42 @@ export default function Database() {
                               </CardDescription>
                             )}
                           </div>
-                          <Heart className="h-5 w-5 text-[#718096] hover:text-red-500 cursor-pointer transition-colors" />
+                          <div className="flex flex-col items-end gap-2">
+                            <Badge
+                              className={
+                                fragrance.verificationStatus === "approved"
+                                  ? "bg-green-100 text-green-800"
+                                  : fragrance.verificationStatus === "pending"
+                                  ? "bg-yellow-100 text-yellow-800"
+                                  : fragrance.verificationStatus === "rejected"
+                                  ? "bg-red-100 text-red-800"
+                                  : "bg-gray-100 text-gray-800"
+                              }
+                            >
+                              {fragrance.verificationStatus}
+                            </Badge>
+                            {user && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="neumorphic-button-sm h-7 px-2 text-xs"
+                                onClick={() => handleProposeEdit("fragrance", fragrance)}
+                              >
+                                Edit
+                              </Button>
+                            )}
+                            {user && fragrance.verificationStatus === "unverified" && (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                className="neumorphic-button-sm h-7 px-2 text-xs"
+                                onClick={() => handleVerify("fragrance", fragrance._id)}
+                              >
+                                Verify
+                              </Button>
+                            )}
+                            <Heart className="h-5 w-5 text-[#718096] hover:text-red-500 cursor-pointer transition-colors" />
+                          </div>
                         </div>
                       </CardHeader>
                       <CardContent className="pt-0">


### PR DESCRIPTION
## Summary
- support content verification with new fields in `schema.ts`
- allow requesting and moderating verification via Convex mutations
- filter marketplace queries to only show approved items
- show verification status in the database UI with edit and verify buttons
- document API usage for verified item queries

## Testing
- `npm run build` *(fails: Cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_68580d3313888327809321b2e95c9446