### PR TITLE
Add basic e-learning tables and pages

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -14,6 +14,7 @@ import type {
   FunctionReference,
 } from "convex/server";
 import type * as bookmarks from "../bookmarks.js";
+import type * as courses from "../courses.js";
 import type * as forum from "../forum.js";
 import type * as marketplace from "../marketplace.js";
 import type * as notifications from "../notifications.js";
@@ -29,6 +30,7 @@ import type * as users from "../users.js";
  */
 declare const fullApi: ApiFromModules<{
   bookmarks: typeof bookmarks;
+  courses: typeof courses;
   forum: typeof forum;
   marketplace: typeof marketplace;
   notifications: typeof notifications;

--- a/convex/courses.ts
+++ b/convex/courses.ts
@@ -1,0 +1,195 @@
+import { v } from "convex/values";
+import { mutation, query } from "./_generated/server";
+import { Id } from "./_generated/dataModel";
+
+// Get all courses
+export const listCourses = query(async ({ db }) => {
+  return await db.query("courses").withIndex("by_created_at").order("desc").collect();
+});
+
+// Get a single course
+export const getCourse = query({
+  args: { courseId: v.id("courses") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.courseId);
+  },
+});
+
+// Get single lesson
+export const getLesson = query({
+  args: { lessonId: v.id("lessons") },
+  handler: async (ctx, args) => {
+    return await ctx.db.get(args.lessonId);
+  },
+});
+
+// Get lessons for a course ordered
+export const getLessons = query({
+  args: { courseId: v.id("courses") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("lessons")
+      .withIndex("by_course_order", (q) => q.eq("courseId", args.courseId))
+      .order("asc")
+      .collect();
+  },
+});
+
+// Save lesson progress and completion
+export const saveProgress = mutation({
+  args: { lessonId: v.id("lessons"), progress: v.number(), completed: v.boolean() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Login required");
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+      .unique();
+    if (!user) throw new Error("User not found");
+
+    const existing = await ctx.db
+      .query("progress")
+      .withIndex("by_user_lesson", (q) => q.eq("userId", user._id).eq("lessonId", args.lessonId))
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        progress: args.progress,
+        completed: args.completed,
+        updatedAt: Date.now(),
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("progress", {
+      userId: user._id,
+      lessonId: args.lessonId,
+      progress: args.progress,
+      completed: args.completed,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+export const getProgress = query({
+  args: { lessonId: v.id("lessons") },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+      .unique();
+    if (!user) return null;
+    return await ctx.db
+      .query("progress")
+      .withIndex("by_user_lesson", (q) => q.eq("userId", user._id).eq("lessonId", args.lessonId))
+      .unique();
+  },
+});
+
+// Fetch quiz questions for a lesson
+export const getQuizQuestions = query({
+  args: { lessonId: v.id("lessons") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("quizzes")
+      .withIndex("by_lesson", (q) => q.eq("lessonId", args.lessonId))
+      .order("asc")
+      .collect();
+  },
+});
+
+// Submit quiz answers and automatically grade
+export const submitQuiz = mutation({
+  args: { lessonId: v.id("lessons"), answers: v.array(v.number()) },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Login required");
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+      .unique();
+    if (!user) throw new Error("User not found");
+
+    const questions = await ctx.db
+      .query("quizzes")
+      .withIndex("by_lesson", (q) => q.eq("lessonId", args.lessonId))
+      .order("asc")
+      .collect();
+
+    let correct = 0;
+    questions.forEach((q, i) => {
+      if (q.correctOption === args.answers[i]) correct++;
+    });
+
+    const score = questions.length ? Math.round((correct / questions.length) * 100) : 0;
+
+    const existing = await ctx.db
+      .query("quizResults")
+      .withIndex("by_user_lesson", (q) => q.eq("userId", user._id).eq("lessonId", args.lessonId))
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        answers: args.answers,
+        score,
+        createdAt: Date.now(),
+      });
+    } else {
+      await ctx.db.insert("quizResults", {
+        lessonId: args.lessonId,
+        userId: user._id,
+        answers: args.answers,
+        score,
+        createdAt: Date.now(),
+      });
+    }
+
+    return score;
+  },
+});
+
+// Generate certificate after course completion
+export const generateCertificate = mutation({
+  args: { courseId: v.id("courses") },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Login required");
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+      .unique();
+    if (!user) throw new Error("User not found");
+
+    const lessons = await ctx.db
+      .query("lessons")
+      .withIndex("by_course", (q) => q.eq("courseId", args.courseId))
+      .collect();
+
+    const progress = await ctx.db
+      .query("progress")
+      .withIndex("by_user", (q) => q.eq("userId", user._id))
+      .collect();
+
+    const completed = lessons.every((l) => progress.find((p) => p.lessonId === l._id && p.completed));
+
+    if (!completed) throw new Error("Course not completed");
+
+    const existing = await ctx.db
+      .query("certificates")
+      .withIndex("by_user_course", (q) => q.eq("userId", user._id).eq("courseId", args.courseId))
+      .unique();
+
+    if (existing) return existing.url;
+
+    const url = `/certificates/${user._id}_${args.courseId}.pdf`;
+    await ctx.db.insert("certificates", {
+      courseId: args.courseId,
+      userId: user._id,
+      url,
+      createdAt: Date.now(),
+    });
+    return url;
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -471,4 +471,69 @@ export default defineSchema({
     .index("by_user", ["userId"])
     .index("by_read", ["read"])
     .index("by_created_at", ["createdAt"]),
+
+  // === Courses & Lessons ===
+  courses: defineTable({
+    title: v.string(),
+    description: v.string(),
+    category: v.string(),
+    level: v.string(),
+    price: v.number(),
+    image: v.optional(v.string()),
+    instructor: v.string(),
+    discussionTopicId: v.optional(v.id("topics")),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_category", ["category"])
+    .index("by_level", ["level"])
+    .index("by_created_at", ["createdAt"]),
+
+  lessons: defineTable({
+    courseId: v.id("courses"),
+    title: v.string(),
+    videoUrl: v.string(),
+    order: v.number(),
+    createdAt: v.number(),
+    updatedAt: v.number(),
+  })
+    .index("by_course_order", ["courseId", "order"])
+    .index("by_course", ["courseId"]),
+
+  progress: defineTable({
+    userId: v.id("users"),
+    lessonId: v.id("lessons"),
+    progress: v.number(),
+    completed: v.boolean(),
+    updatedAt: v.number(),
+  })
+    .index("by_user_lesson", ["userId", "lessonId"])
+    .index("by_user", ["userId"]),
+
+  quizzes: defineTable({
+    lessonId: v.id("lessons"),
+    question: v.string(),
+    options: v.array(v.string()),
+    correctOption: v.number(),
+    createdAt: v.number(),
+  }).index("by_lesson", ["lessonId"]),
+
+  quizResults: defineTable({
+    lessonId: v.id("lessons"),
+    userId: v.id("users"),
+    answers: v.array(v.number()),
+    score: v.number(),
+    createdAt: v.number(),
+  })
+    .index("by_user_lesson", ["userId", "lessonId"])
+    .index("by_user", ["userId"]),
+
+  certificates: defineTable({
+    courseId: v.id("courses"),
+    userId: v.id("users"),
+    url: v.string(),
+    createdAt: v.number(),
+  })
+    .index("by_user_course", ["userId", "courseId"])
+    .index("by_user", ["userId"]),
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,8 @@ import MarketplaceSambatDetail from "./pages/marketplace-sambat-detail";
 import MarketplaceProduct from "./pages/marketplace-product";
 import Admin from "./pages/admin";
 import Kursus from "./pages/kursus";
+import CourseDetail from "./pages/course-detail";
+import LessonPage from "./pages/lesson";
 import Database from "./pages/database";
 import Privacy from "./pages/privacy";
 import Terms from "./pages/terms";
@@ -64,6 +66,8 @@ function App() {
           />
           <Route path="/admin" element={<Admin />} />
           <Route path="/kursus" element={<Kursus />} />
+          <Route path="/kursus/:id" element={<CourseDetail />} />
+          <Route path="/lesson/:id" element={<LessonPage />} />
           <Route path="/database" element={<Database />} />
           <Route path="/privacy" element={<Privacy />} />
           <Route path="/terms" element={<Terms />} />

--- a/src/components/lesson-player.tsx
+++ b/src/components/lesson-player.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef } from "react";
+import { useMutation, useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { Id } from "../../convex/_generated/dataModel";
+
+interface LessonPlayerProps {
+  lessonId: Id<"lessons">;
+}
+
+export default function LessonPlayer({ lessonId }: LessonPlayerProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const lesson = useQuery(api.courses.getLesson, { lessonId });
+  const userProgress = useQuery(api.courses.getProgress, { lessonId });
+  const save = useMutation(api.courses.saveProgress);
+
+  useEffect(() => {
+    if (!lesson || !userProgress || !videoRef.current) return;
+    const vid = videoRef.current;
+    const setTime = () => {
+      vid.currentTime = (userProgress.progress / 100) * vid.duration;
+    };
+    if (vid.readyState >= 2) setTime();
+    else vid.onloadedmetadata = setTime;
+  }, [lesson, userProgress]);
+
+  if (lesson === undefined) return <div>Loading...</div>;
+  if (lesson === null) return <div>Lesson not found</div>;
+
+  const handleTimeUpdate = () => {
+    if (!videoRef.current) return;
+    const vid = videoRef.current;
+    const progressValue = (vid.currentTime / vid.duration) * 100;
+    save({ lessonId, progress: progressValue, completed: progressValue >= 100 });
+  };
+
+  return (
+    <div className="w-full">
+      <video
+        ref={videoRef}
+        controls
+        src={lesson.videoUrl}
+        className="w-full rounded-lg"
+        onTimeUpdate={handleTimeUpdate}
+      />
+    </div>
+  );
+}

--- a/src/pages/course-detail.tsx
+++ b/src/pages/course-detail.tsx
@@ -1,0 +1,51 @@
+import { Link, useParams } from "react-router-dom";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+
+export default function CourseDetail() {
+  const { id } = useParams();
+  const course = useQuery(
+    api.courses.getCourse,
+    id ? { courseId: id as any } : "skip"
+  );
+  const lessons = useQuery(
+    api.courses.getLessons,
+    id ? { courseId: id as any } : "skip"
+  );
+
+  if (course === undefined || lessons === undefined) return <div>Loading...</div>;
+  if (course === null) return <div>Course not found</div>;
+
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <Navbar />
+      <main className="flex-grow container mx-auto px-4 py-8 space-y-4">
+        <h1 className="text-2xl font-bold">{course.title}</h1>
+        <p className="text-gray-600">{course.description}</p>
+        {course.discussionTopicId && (
+          <Link
+            to={`/forum?topic=${course.discussionTopicId}`}
+            className="text-indigo-600 underline"
+          >
+            Diskusi Kursus
+          </Link>
+        )}
+        <ul className="space-y-2">
+          {lessons?.map((lesson) => (
+            <li key={lesson._id}>
+              <Link
+                to={`/lesson/${lesson._id}`}
+                className="text-indigo-600 underline"
+              >
+                {lesson.title}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/lesson.tsx
+++ b/src/pages/lesson.tsx
@@ -1,0 +1,70 @@
+import { useParams } from "react-router-dom";
+import { useQuery, useMutation } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import LessonPlayer from "@/components/lesson-player";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { Button } from "@/components/ui/button";
+import { useState } from "react";
+
+export default function LessonPage() {
+  const { id } = useParams();
+  const lesson = useQuery(
+    api.courses.getLesson,
+    id ? { lessonId: id as any } : "skip"
+  );
+  const questions = useQuery(
+    api.courses.getQuizQuestions,
+    id ? { lessonId: id as any } : "skip"
+  );
+  const submit = useMutation(api.courses.submitQuiz);
+  const [answers, setAnswers] = useState<number[]>([]);
+  const [score, setScore] = useState<number | null>(null);
+
+  const handleSubmit = async () => {
+    if (!id) return;
+    const result = await submit({ lessonId: id as any, answers });
+    setScore(result);
+  };
+
+  if (lesson === undefined || questions === undefined) return <div>Loading...</div>;
+  if (lesson === null) return <div>Lesson not found</div>;
+
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <Navbar />
+      <main className="flex-grow container mx-auto px-4 py-8 space-y-6">
+        <h1 className="text-xl font-semibold">{lesson.title}</h1>
+        <LessonPlayer lessonId={lesson._id} />
+        {questions.length > 0 && (
+          <div className="space-y-4">
+            {questions.map((q, idx) => (
+              <div key={q._id} className="space-y-2">
+                <p>{q.question}</p>
+                {q.options.map((opt: string, i: number) => (
+                  <label key={i} className="block">
+                    <input
+                      type="radio"
+                      name={`q${idx}`}
+                      value={i}
+                      checked={answers[idx] === i}
+                      onChange={() => {
+                        const copy = [...answers];
+                        copy[idx] = i;
+                        setAnswers(copy);
+                      }}
+                    />{" "}
+                    {opt}
+                  </label>
+                ))}
+              </div>
+            ))}
+            <Button onClick={handleSubmit}>Kirim</Button>
+            {score !== null && <p>Skor: {score}</p>}
+          </div>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Convex schema tables for courses, lessons, quizzes and certificates
- add server functions for course progress tracking and certificate creation
- create lesson player and new course pages
- wire pages into router

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68580d3f9ccc8327b5d9be2e115d6a51