### PR TITLE
Add voting to forum topics and comments

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -37,6 +37,7 @@ export default defineSchema({
     authorName: v.string(),
     views: v.number(),
     likes: v.number(),
+    score: v.number(),
     isHot: v.boolean(),
     isPinned: v.boolean(),
     hasVideo: v.boolean(),
@@ -59,6 +60,7 @@ export default defineSchema({
     authorId: v.id("users"),
     authorName: v.string(),
     likes: v.number(),
+    score: v.number(),
     createdAt: v.number(),
     updatedAt: v.number(),
   })
@@ -78,6 +80,26 @@ export default defineSchema({
   commentLikes: defineTable({
     commentId: v.id("comments"),
     userId: v.id("users"),
+    createdAt: v.number(),
+  })
+    .index("by_comment", ["commentId"])
+    .index("by_user", ["userId"])
+    .index("by_comment_user", ["commentId", "userId"]),
+
+  topicVotes: defineTable({
+    topicId: v.id("topics"),
+    userId: v.id("users"),
+    value: v.number(),
+    createdAt: v.number(),
+  })
+    .index("by_topic", ["topicId"])
+    .index("by_user", ["userId"])
+    .index("by_topic_user", ["topicId", "userId"]),
+
+  commentVotes: defineTable({
+    commentId: v.id("comments"),
+    userId: v.id("users"),
+    value: v.number(),
     createdAt: v.number(),
   })
     .index("by_comment", ["commentId"])


### PR DESCRIPTION
## Summary
- add score tracking to forum topics and comments
- store topic and comment votes in new tables
- implement toggleTopicVote and toggleCommentVote server mutations
- display upvote/downvote buttons for topics and comments

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm run build-no-errors` *(fails: missing module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6858145ff5f08327a5bfe0647754ec4e