### PR TITLE
Use Convex search API for forum

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -51,7 +51,8 @@ export default defineSchema({
     .index("by_category", ["category"])
     .index("by_created_at", ["createdAt"])
     .index("by_likes", ["likes"])
-    .index("by_views", ["views"]),
+    .index("by_views", ["views"])
+    .searchIndex("search_title", { searchField: "title", filterFields: ["category"] }),
 
   comments: defineTable({
     topicId: v.id("topics"),


### PR DESCRIPTION
## Summary
- add a `search_title` search index on `topics`
- replace manual `includes()` filtering with `withSearchIndex` query in `getTopics`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*

------
https://chatgpt.com/codex/tasks/task_e_685815ed36848327bd15f216513101c1