### PR TITLE
Add not-found page and wildcard route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import MarketplaceCheckout from "./pages/marketplace-checkout";
 import Settings from "./pages/settings";
 import { Toaster } from "@/components/ui/toaster";
 import NotificationListener from "@/components/notification-listener";
+import NotFound from "./pages/not-found";
 
 function App() {
   return (
@@ -80,6 +81,7 @@ function App() {
           <Route path="/polling" element={<Polling />} />
           <Route path="/faq" element={<FAQ />} />
           <Route path="/order/:orderId/review" element={<OrderReviewPage />} />
+          <Route path="*" element={<NotFound />} />
         </Routes>
         {import.meta.env.VITE_TEMPO === "true" && useRoutes(routes)}
         <NotificationListener />

--- a/src/pages/not-found.tsx
+++ b/src/pages/not-found.tsx
@@ -1,0 +1,19 @@
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { Link } from "react-router-dom";
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <Navbar />
+      <main className="flex-grow flex flex-col items-center justify-center text-center space-y-4">
+        <h1 className="text-3xl font-bold">Page Not Found</h1>
+        <p className="text-[#4a5568]">The page you are looking for does not exist.</p>
+        <Link to="/" className="text-blue-600">
+          Back to Home
+        </Link>
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a NotFound page with a link back home
- register a wildcard route in the app

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68593d010d4883279ddbe4530458e541