### PR TITLE
Add onboarding page and links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ import Privacy from "./pages/privacy";
 import Terms from "./pages/terms";
 import Polling from "./pages/polling";
 import FAQ from "./pages/faq";
+import Onboarding from "./pages/onboarding";
 import Login from "./pages/login";
 import Signup from "./pages/signup";
 import ResetPassword from "./pages/reset-password";
@@ -79,6 +80,7 @@ function App() {
           <Route path="/terms" element={<Terms />} />
           <Route path="/polling" element={<Polling />} />
           <Route path="/faq" element={<FAQ />} />
+          <Route path="/onboarding" element={<Onboarding />} />
           <Route path="/order/:orderId/review" element={<OrderReviewPage />} />
         </Routes>
         {import.meta.env.VITE_TEMPO === "true" && useRoutes(routes)}

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -117,6 +117,9 @@ function App() {
                         {t('home.hero.buttonStart')}
                       </Button>
                     </Link>
+                    <Link to="/onboarding" className="text-sm text-[#667eea] underline ml-4 inline-flex items-center">
+                      Panduan Singkat
+                    </Link>
                   </Unauthenticated>
                 </>
               )}

--- a/src/pages/onboarding.tsx
+++ b/src/pages/onboarding.tsx
@@ -1,0 +1,38 @@
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+export default function Onboarding() {
+  const guides = [
+    {
+      title: "Forum",
+      desc: "Buat dan balas topik untuk berdiskusi dengan komunitas parfum.",
+    },
+    {
+      title: "Marketplace",
+      desc: "Jual beli parfum langka dan koleksi eksklusif dengan aman.",
+    },
+    {
+      title: "Reward System",
+      desc: "Dapatkan poin dari aktivitas dan tukarkan dengan badge menarik.",
+    },
+  ];
+
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <Navbar />
+      <main className="flex-grow container mx-auto px-4 py-16 space-y-6">
+        <h1 className="text-3xl font-bold text-center mb-8">Panduan Singkat</h1>
+        {guides.map((g, idx) => (
+          <Card key={idx} className="neumorphic-card border-0">
+            <CardHeader>
+              <CardTitle>{g.title}</CardTitle>
+            </CardHeader>
+            <CardContent className="text-[#4a5568]">{g.desc}</CardContent>
+          </Card>
+        ))}
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -7,7 +7,7 @@ export default function Signup() {
     <div className="min-h-screen flex flex-col neumorphic-bg">
       <Navbar />
       <main className="flex-grow flex items-center justify-center">
-        <SignUp path="/signup" routing="path" signInUrl="/login" afterSignUpUrl="/dashboard" />
+        <SignUp path="/signup" routing="path" signInUrl="/login" afterSignUpUrl="/onboarding" />
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- provide onboarding page for a short guide
- redirect to onboarding after signup
- link onboarding from the home page hero
- register onboarding route

## Testing
- `npm run build-no-errors` *(fails: Cannot find namespace 'React')*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68593d2125708327b53feaa278e68f6e