### PR TITLE
Add global search bar and API

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -20,6 +20,7 @@ import type * as marketplace from "../marketplace.js";
 import type * as notifications from "../notifications.js";
 import type * as rewards from "../rewards.js";
 import type * as users from "../users.js";
+import type * as search from "../search.js";
 
 /**
  * A utility for referencing Convex functions in your app's API.
@@ -37,7 +38,8 @@ declare const fullApi: ApiFromModules<{
   notifications: typeof notifications;
   rewards: typeof rewards;
   users: typeof users;
-}>;
+  search: typeof search;
+}>; 
 export declare const api: FilterApi<
   typeof fullApi,
   FunctionReference<any, "public">

--- a/convex/search.ts
+++ b/convex/search.ts
@@ -1,0 +1,29 @@
+import { v } from "convex/values";
+import { query } from "./_generated/server";
+
+export const crossSearch = query({
+  args: { term: v.string(), limit: v.optional(v.number()) },
+  handler: async (ctx, { term, limit }) => {
+    const lower = term.toLowerCase();
+    const max = limit ?? 5;
+
+    const topics = await ctx.db
+      .query("topics")
+      .withSearchIndex("search_title", (q) => q.search("title", term))
+      .take(max);
+
+    const products = await ctx.db
+      .query("products")
+      .withIndex("by_status", (q) => q.eq("status", "active"))
+      .collect();
+
+    const filteredProducts = products.filter((p) =>
+      p.title.toLowerCase().includes(lower) ||
+      p.description.toLowerCase().includes(lower) ||
+      p.brand.toLowerCase().includes(lower) ||
+      p.tags.some((t) => t.toLowerCase().includes(lower))
+    ).slice(0, max);
+
+    return { topics, products: filteredProducts };
+  },
+});

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -11,6 +11,7 @@ import { Link } from "react-router-dom";
 import { api } from "../../convex/_generated/api";
 import { Button } from "./ui/button";
 import { Badge } from "./ui/badge";
+import { SearchBar } from "./search-bar";
 import { LanguageToggle } from "./language-toggle";
 import { Sheet, SheetTrigger, SheetContent } from "./ui/sheet";
 import {
@@ -332,6 +333,7 @@ export function Navbar() {
 
           {isLoaded ? (
             <div className="flex items-center gap-4">
+              <SearchBar />
               <LanguageToggle />
               <Authenticated>
                 {/* Notification Bell */}

--- a/src/components/search-bar.tsx
+++ b/src/components/search-bar.tsx
@@ -1,0 +1,48 @@
+import { useState } from "react";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { Input } from "@/components/ui/input";
+import { Search as SearchIcon } from "lucide-react";
+import { Link } from "react-router-dom";
+
+export function SearchBar() {
+  const [term, setTerm] = useState("");
+  const results = useQuery(api.search.crossSearch, term ? { term } : "skip");
+
+  return (
+    <div className="relative w-full max-w-xs">
+      <SearchIcon className="absolute left-2 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
+      <Input
+        value={term}
+        onChange={(e) => setTerm(e.target.value)}
+        placeholder="Search..."
+        className="pl-8 neumorphic-input border-0"
+      />
+      {results && term && (
+        <div className="absolute mt-1 w-full neumorphic-card border-0 max-h-60 overflow-y-auto z-50">
+          {results.topics.length === 0 && results.products.length === 0 && (
+            <div className="p-2 text-sm text-gray-500">No results</div>
+          )}
+          {results.topics.map((t: any) => (
+            <Link
+              key={t._id}
+              to={`/forum`}
+              className="block px-2 py-1 hover:bg-[#F5F5F7] text-sm"
+            >
+              {t.title}
+            </Link>
+          ))}
+          {results.products.map((p: any) => (
+            <Link
+              key={p._id}
+              to={`/marketplace/product/${p._id}`}
+              className="block px-2 py-1 hover:bg-[#F5F5F7] text-sm"
+            >
+              {p.title}
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `crossSearch` query on Convex backend for topics and products
- create `SearchBar` component using the new API
- show the search bar on the navbar so all pages have search
- update API typings to include new search module

## Testing
- `npm run lint` *(fails: ESLint config missing)*
- `npm run build` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68593d42c9688327bf926fb1edcea179