### PR TITLE
Add alt text for forum images

### DIFF
--- a/src/pages/forum.tsx
+++ b/src/pages/forum.tsx
@@ -1211,6 +1211,7 @@ export default function Forum() {
                                   <img
                                     key={idx}
                                     src={url}
+                                    alt={selectedTopic.title}
                                     className="w-full rounded-lg"
                                   />
                                 ))}


### PR DESCRIPTION
## Summary
- add descriptive alt attribute when rendering topic images in the forum

## Testing
- `npm run lint` *(fails: couldn't find an eslint config)*

------
https://chatgpt.com/codex/tasks/task_e_68593f9471048327bdf92ca663d33f36