### PR TITLE
Add seed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,3 +68,13 @@ Detail perencanaan fitur dapat dilihat di: [`planning/USER/profile-plan.md`](/pl
 - **Integrasi**: Notifikasi pencapaian dan update real-time menggunakan Convex subscriptions.
 
 _Versi dokumen: 1.1.0 (Updated: Juni 2025)_
+
+## Development Seeds
+
+Populate your Convex deployment with sample marketplace data using:
+
+```bash
+CONVEX_URL=<your_convex_url> npx ts-node scripts/seed.ts
+```
+
+The command calls `api.marketplace.initializeSampleData` to insert starter brands, perfumers and fragrances for local testing.

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,0 +1,25 @@
+import { ConvexHttpClient } from "convex/browser";
+import { api } from "../convex/_generated/api.js";
+
+const convexUrl = process.env.CONVEX_URL;
+if (!convexUrl) {
+  console.error("CONVEX_URL environment variable not set");
+  process.exit(1);
+}
+
+const client = new ConvexHttpClient(convexUrl);
+
+async function main() {
+  try {
+    const result = await client.mutation(
+      api.marketplace.initializeSampleData,
+      {},
+    );
+    console.log(result);
+  } catch (err: any) {
+    console.error("Failed to seed sample data:", err.message);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- implement `scripts/seed.ts` to invoke `initializeSampleData`
- document seeding process in `README`

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_68593f9a25fc832789a9e7a0371de709