### PR TITLE
Implement language toggle button

### DIFF
--- a/src/components/language-toggle.tsx
+++ b/src/components/language-toggle.tsx
@@ -1,5 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
+import { Globe } from "lucide-react";
 
 export function LanguageToggle() {
   const { i18n } = useTranslation();
@@ -11,5 +12,15 @@ export function LanguageToggle() {
     }
   };
 
-  return <></>;
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      className="neumorphic-button-sm border-0 shadow-none bg-transparent"
+      onClick={toggle}
+      aria-label="Toggle language"
+    >
+      <Globe className="w-5 h-5 text-[#1D1D1F]" />
+    </Button>
+  );
 }


### PR DESCRIPTION
## Summary
- add a Globe button in `LanguageToggle` and invoke the toggle handler
- save the language preference in `localStorage`

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68593fa50ca48327beac37b0ce720cb3