### PR TITLE
Add forum moderation features

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -43,6 +43,8 @@ export default defineSchema({
     score: v.number(),
     isHot: v.boolean(),
     isPinned: v.boolean(),
+    isLocked: v.boolean(),
+    solvedCommentId: v.optional(v.id("comments")),
     hasVideo: v.boolean(),
     hasImages: v.boolean(),
     tags: v.array(v.string()),
@@ -109,6 +111,16 @@ export default defineSchema({
     .index("by_comment", ["commentId"])
     .index("by_user", ["userId"])
     .index("by_comment_user", ["commentId", "userId"]),
+
+  topicReports: defineTable({
+    topicId: v.id("topics"),
+    reporterId: v.id("users"),
+    reason: v.string(),
+    createdAt: v.number(),
+  })
+    .index("by_topic", ["topicId"])
+    .index("by_reporter", ["reporterId"])
+    .index("by_topic_reporter", ["topicId", "reporterId"]),
 
   products: defineTable({
     title: v.string(),


### PR DESCRIPTION
## Summary
- support locked/solved state and topic reports in the backend
- expose moderation mutations for locking and reporting threads
- add hot thread query
- show solved and locked state in the forum UI
- allow marking comments as the solution

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run build` *(fails: several missing module type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685be1673d248327b4094a22afb02d8f