### PR TITLE
Add Cloudinary support and email templates

### DIFF
--- a/convex/users.ts
+++ b/convex/users.ts
@@ -188,6 +188,7 @@ export const updateUserProfile = mutation({
     instagram: v.optional(v.string()),
     twitter: v.optional(v.string()),
     website: v.optional(v.string()),
+    avatar: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
@@ -206,17 +207,18 @@ export const updateUserProfile = mutation({
       .withIndex("by_user", (q) => q.eq("userId", user._id))
       .unique();
     const now = Date.now();
-    const profilePatch = {
-      bio: args.bio,
-      location: args.location,
-      interests: args.interests,
-      phone: args.phone,
-      whatsapp: args.whatsapp,
-      instagram: args.instagram,
-      twitter: args.twitter,
-      website: args.website,
-      lastActive: now,
-    } as any;
+  const profilePatch = {
+    bio: args.bio,
+    location: args.location,
+    interests: args.interests,
+    phone: args.phone,
+    whatsapp: args.whatsapp,
+    instagram: args.instagram,
+    twitter: args.twitter,
+    website: args.website,
+    avatar: args.avatar,
+    lastActive: now,
+  } as any;
     if (existing) {
       await ctx.db.patch(existing._id, profilePatch);
       return existing._id;
@@ -224,7 +226,7 @@ export const updateUserProfile = mutation({
     return await ctx.db.insert("userProfiles", {
       userId: user._id,
       ...profilePatch,
-      avatar: null,
+      avatar: args.avatar ?? null,
       isVerified: false,
       rating: 0,
       totalReviews: 0,

--- a/package.json
+++ b/package.json
@@ -69,7 +69,9 @@
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.1",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "react-email": "^4.0.17",
+    "@react-email/components": "^0.1.1"
   },
   "devDependencies": {
     "@swc/core": "1.3.96",

--- a/src/emails/ForumNotificationEmail.tsx
+++ b/src/emails/ForumNotificationEmail.tsx
@@ -1,0 +1,23 @@
+import { Html, Head, Preview, Body, Container, Heading, Text, Button } from "@react-email/components";
+
+interface ForumNotificationEmailProps {
+  topic: string;
+  message: string;
+  url: string;
+}
+
+export default function ForumNotificationEmail({ topic, message, url }: ForumNotificationEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Aktivitas Baru di Forum</Preview>
+      <Body style={{ fontFamily: 'Arial, sans-serif' }}>
+        <Container>
+          <Heading>Notifikasi Forum</Heading>
+          <Text>{message} pada topik <strong>{topic}</strong>.</Text>
+          <Button href={url}>Lihat Diskusi</Button>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/src/emails/OrderConfirmationEmail.tsx
+++ b/src/emails/OrderConfirmationEmail.tsx
@@ -1,0 +1,23 @@
+import { Html, Head, Preview, Body, Container, Heading, Text, Button } from "@react-email/components";
+
+interface OrderConfirmationEmailProps {
+  orderId: string;
+  productName: string;
+  url: string;
+}
+
+export default function OrderConfirmationEmail({ orderId, productName, url }: OrderConfirmationEmailProps) {
+  return (
+    <Html>
+      <Head />
+      <Preview>Konfirmasi Pesanan #{orderId}</Preview>
+      <Body style={{ fontFamily: 'Arial, sans-serif' }}>
+        <Container>
+          <Heading>Terima kasih atas pesanan Anda!</Heading>
+          <Text>Pesanan <strong>{productName}</strong> dengan ID {orderId} telah kami terima.</Text>
+          <Button href={url}>Lihat Pesanan</Button>
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/src/pages/marketplace-sell.tsx
+++ b/src/pages/marketplace-sell.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Navbar } from "@/components/navbar";
@@ -18,6 +18,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Switch } from "@/components/ui/switch";
 import { Label } from "@/components/ui/label";
+import { uploadImage } from "@/utils/cloudinary";
 import { Progress } from "@/components/ui/progress";
 import {
   Upload,
@@ -104,6 +105,7 @@ function MarketplaceSellContent() {
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [currentStep, setCurrentStep] = useState(1);
   const [showTips, setShowTips] = useState(true);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Auto-create user if not exists
   useEffect(() => {
@@ -128,6 +130,22 @@ function MarketplaceSellContent() {
         ...prev,
         images: [...prev.images, url.trim()],
       }));
+    }
+  };
+
+  const handleImageFileChange = async (
+    e: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      const url = await uploadImage(file, "products");
+      setImageUrls((prev) => [...prev, url]);
+      setFormData((prev) => ({ ...prev, images: [...prev.images, url] }));
+    } catch (err) {
+      console.error(err);
+    } finally {
+      if (fileInputRef.current) fileInputRef.current.value = "";
     }
   };
 
@@ -681,6 +699,20 @@ function MarketplaceSellContent() {
                           Foto Produk (Opsional)
                         </Label>
                         <div className="space-y-4">
+                          <input
+                            type="file"
+                            accept="image/*"
+                            ref={fileInputRef}
+                            onChange={handleImageFileChange}
+                            className="hidden"
+                          />
+                          <Button
+                            type="button"
+                            onClick={() => fileInputRef.current?.click()}
+                            className="w-full neumorphic-button text-[#2d3748] bg-transparent border-0 shadow-none"
+                          >
+                            <Upload className="h-4 w-4 mr-2" /> Upload Gambar
+                          </Button>
                           <Button
                             type="button"
                             onClick={handleImageUrlAdd}

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Link } from "react-router-dom";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { uploadImage } from "@/utils/cloudinary";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
@@ -107,9 +108,12 @@ function ProfileContent() {
 
   const handleImageChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
-    if (file && user) {
-      // @ts-ignore
-      await user.setProfileImage({ file });
+    if (!file || !userData) return;
+    try {
+      const url = await uploadImage(file, "avatars");
+      await updateProfile({ avatar: url });
+    } catch (err) {
+      console.error(err);
     }
   };
   const averageRating =
@@ -189,7 +193,7 @@ function ProfileContent() {
                   <div className="relative w-24 h-24 mx-auto mb-4">
                     <Avatar className="w-24 h-24 mx-auto neumorphic-button border-0">
                       <AvatarImage
-                        src={user?.imageUrl}
+                        src={userProfile?.profile?.avatar || user?.imageUrl}
                         alt={user?.fullName || "User"}
                       />
                       <AvatarFallback className="text-2xl font-semibold text-[#2d3748] bg-gradient-to-br from-[#e0e5ec] to-[#ffffff]">

--- a/src/utils/cloudinary.ts
+++ b/src/utils/cloudinary.ts
@@ -1,0 +1,43 @@
+const CLOUDINARY_CLOUD_NAME =
+  (import.meta as any).env?.VITE_CLOUDINARY_CLOUD_NAME ||
+  (typeof process !== 'undefined' ? process.env.CLOUDINARY_CLOUD_NAME : '');
+const CLOUDINARY_UPLOAD_PRESET =
+  (import.meta as any).env?.VITE_CLOUDINARY_UPLOAD_PRESET ||
+  (typeof process !== 'undefined' ? process.env.CLOUDINARY_UPLOAD_PRESET : '');
+
+export async function uploadImage(
+  file: File,
+  folder?: string,
+): Promise<string> {
+  const formData = new FormData();
+  formData.append('file', file);
+  if (CLOUDINARY_UPLOAD_PRESET) formData.append('upload_preset', CLOUDINARY_UPLOAD_PRESET);
+  if (folder) formData.append('folder', folder);
+
+  const res = await fetch(
+    `https://api.cloudinary.com/v1_1/${CLOUDINARY_CLOUD_NAME}/image/upload`,
+    {
+      method: 'POST',
+      body: formData,
+    },
+  );
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Cloudinary upload failed: ${res.status} ${text}`);
+  }
+  const data = await res.json();
+  return data.secure_url as string;
+}
+
+export function transformImage(
+  url: string,
+  options: { width?: number; height?: number; crop?: string } = {},
+): string {
+  const params = [] as string[];
+  if (options.width) params.push(`w_${options.width}`);
+  if (options.height) params.push(`h_${options.height}`);
+  if (options.crop) params.push(`c_${options.crop}`);
+  if (params.length === 0) return url;
+  const transformation = params.join(',');
+  return url.replace('/upload/', `/upload/${transformation}/`);
+}


### PR DESCRIPTION
## Summary
- implement image upload helpers in `cloudinary.ts`
- store uploaded profile images in Cloudinary
- allow marketplace sellers to upload product pictures
- extend user profile API to accept avatar URLs
- add React Email templates for order and forum notifications
- include React Email packages

## Testing
- `npm run build-no-errors` *(fails: Cannot find namespace 'React' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c0d35ae80832799059524809f3a4f