### PR TITLE
Add admin analytics and system tools

### DIFF
--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -1,12 +1,18 @@
-import { mutation, query } from "./_generated/server";
+import { mutation, query, action } from "./_generated/server";
 import { v } from "convex/values";
+import os from "node:os";
 
 export const getSystemHealth = query({
   handler: async () => {
+    const uptimeSeconds = process.uptime();
+    const totalMem = os.totalmem();
+    const usedMem = totalMem - os.freemem();
+    const memoryUsage = `${((usedMem / totalMem) * 100).toFixed(1)}%`;
+
     return {
-      uptime: "99.9%",
-      memoryUsage: "0%",
-      diskUsage: "0%",
+      uptime: `${Math.floor(uptimeSeconds / 60)}m`,
+      memoryUsage,
+      diskUsage: "N/A",
       activeConnections: 0,
     };
   },
@@ -15,27 +21,135 @@ export const getSystemHealth = query({
 export const suspendUser = mutation({
   args: { userId: v.id("users") },
   handler: async (ctx, args) => {
-    await ctx.db.patch(args.userId, { role: "suspended" });
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthenticated");
+    const adminUser = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+      .unique();
+    if (!adminUser || adminUser.role !== "admin") {
+      throw new Error("Unauthorized");
+    }
+    await ctx.db.patch(args.userId, {
+      role: "suspended",
+      suspendedAt: Date.now(),
+    });
   },
 });
 
 export const deleteUser = mutation({
   args: { userId: v.id("users") },
   handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthenticated");
+    const adminUser = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+      .unique();
+    if (!adminUser || adminUser.role !== "admin") {
+      throw new Error("Unauthorized");
+    }
     await ctx.db.delete(args.userId);
   },
 });
 
 export const broadcastSystemMessage = mutation({
   args: { message: v.string() },
-  handler: async (_ctx, _args) => {},
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthenticated");
+    const adminUser = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+      .unique();
+    if (!adminUser || adminUser.role !== "admin") {
+      throw new Error("Unauthorized");
+    }
+    const allUsers = await ctx.db.query("users").collect();
+    const now = Date.now();
+    await Promise.all(
+      allUsers.map((u) =>
+        ctx.db.insert("notifications", {
+          userId: u._id,
+          type: "system",
+          message: args.message,
+          read: false,
+          createdAt: now,
+        }),
+      ),
+    );
+  },
 });
 
 export const clearSystemCache = mutation({
   args: { type: v.string() },
-  handler: async () => {},
+  handler: async () => {
+    // Placeholder - in a real app this would clear CDN or application caches
+    return true;
+  },
 });
 
 export const backupDatabase = mutation({
-  handler: async () => {},
+  handler: async (ctx) => {
+    const tables = [
+      "users",
+      "userProfiles",
+      "products",
+      "orders",
+      "topics",
+      "comments",
+      "topicReports",
+    ];
+    const backup: Record<string, any[]> = {};
+    for (const table of tables) {
+      backup[table] = await ctx.db.query(table as any).collect();
+    }
+    const blob = new Blob([JSON.stringify(backup, null, 2)], {
+      type: "application/json",
+    });
+    const storageId = await ctx.storage.store(blob);
+    return storageId;
+  },
+});
+
+export const getPendingReports = query({
+  handler: async (ctx) => {
+    const reports = await ctx.db.query("topicReports").collect();
+    const topics = await ctx.db.query("topics").collect();
+    const users = await ctx.db.query("users").collect();
+    const topicMap = new Map(topics.map((t) => [t._id, t.title]));
+    const userMap = new Map(users.map((u) => [u._id, u.name]));
+    return reports.map((r) => ({
+      id: r._id,
+      type: "Topic",
+      content: `${topicMap.get(r.topicId) ?? ""} - ${r.reason}`,
+      reporter: userMap.get(r.reporterId) ?? "Unknown",
+      status: "pending",
+    }));
+  },
+});
+
+export const getPlatformAnalytics = query({
+  handler: async (ctx) => {
+    const users = await ctx.db.query("users").collect();
+    const topics = await ctx.db.query("topics").collect();
+    const comments = await ctx.db.query("comments").collect();
+    const orders = await ctx.db.query("orders").collect();
+    const pendingReports = await ctx.db.query("topicReports").collect();
+
+    return {
+      userCount: users.length,
+      topicCount: topics.length,
+      commentCount: comments.length,
+      orderCount: orders.length,
+      pendingReports: pendingReports.length,
+    };
+  },
+});
+
+export const getPendingPayments = query({
+  handler: async (ctx) => {
+    const orders = await ctx.db.query("orders").collect();
+    return orders.filter((o) => o.paymentStatus !== "paid");
+  },
 });

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -88,6 +88,8 @@ function AdminContent() {
   const allUsers = useQuery(api.users.getAllUsers);
   const forumStats = useQuery(api.forum.getForumStats);
   const systemHealth = useQuery(api.admin.getSystemHealth);
+  const platformAnalytics = useQuery(api.admin.getPlatformAnalytics);
+  const pendingReports = useQuery(api.admin.getPendingReports);
 
   const verifyPayment = useMutation(api.marketplace.verifyOrderPayment);
   const updateStatus = useMutation(api.marketplace.updateOrderStatus);
@@ -101,63 +103,20 @@ function AdminContent() {
 
   // Data statistik real-time
   const stats = {
-    totalUsers: allUsers?.length || 0,
-    totalPosts: forumStats?.totalPosts || 0,
-    pendingReports: 12, // Mock data - bisa diganti dengan query real
+    totalUsers: platformAnalytics?.userCount || 0,
+    totalPosts:
+      (platformAnalytics?.topicCount || 0) +
+      (platformAnalytics?.commentCount || 0),
+    pendingReports: platformAnalytics?.pendingReports || 0,
     activeDiscussions: forumStats?.activeToday || 0,
     systemUptime: systemHealth?.uptime || "99.9%",
-    memoryUsage: systemHealth?.memoryUsage || "45%",
-    diskUsage: systemHealth?.diskUsage || "67%",
-    activeConnections: systemHealth?.activeConnections || 234,
+    memoryUsage: systemHealth?.memoryUsage || "0%",
+    diskUsage: systemHealth?.diskUsage || "N/A",
+    activeConnections: systemHealth?.activeConnections || 0,
   };
 
-  const recentReports = [
-    {
-      id: 1,
-      type: "Spam",
-      content: "Posting berulang tentang produk...",
-      reporter: "user123",
-      status: "pending",
-    },
-    {
-      id: 2,
-      type: "Konten Tidak Pantas",
-      content: "Komentar yang menyinggung...",
-      reporter: "user456",
-      status: "pending",
-    },
-    {
-      id: 3,
-      type: "Penipuan",
-      content: "Penjualan produk palsu...",
-      reporter: "user789",
-      status: "resolved",
-    },
-  ];
+  const recentReports = pendingReports || [];
 
-  const recentUsers = [
-    {
-      id: 1,
-      name: "Ahmad Rizki",
-      email: "ahmad@email.com",
-      joinDate: "2024-01-15",
-      status: "active",
-    },
-    {
-      id: 2,
-      name: "Sari Dewi",
-      email: "sari@email.com",
-      joinDate: "2024-01-14",
-      status: "active",
-    },
-    {
-      id: 3,
-      name: "Budi Santoso",
-      email: "budi@email.com",
-      joinDate: "2024-01-13",
-      status: "suspended",
-    },
-  ];
 
   return (
     <div className="min-h-screen bg-[#F5F5F7]">


### PR DESCRIPTION
## Summary
- implement admin Convex functions for suspending users, broadcasting messages, database backup and more
- fetch platform analytics and pending reports
- show dynamic stats and report list on the admin page

## Testing
- `npm run build-no-errors` *(fails: Cannot find namespace 'React' and missing type declarations)*
- `npm run lint` *(fails: ESLint config missing)*
- `npx tsc --noEmit` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c0d4035448327b048d133f2e66f5a