### PR TITLE
Add user settings mutation and notification toggles

### DIFF
--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -5,8 +5,10 @@ import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
 import ProtectedRoute from "@/components/wrappers/ProtectedRoute";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 export default function Settings() {
   return (
@@ -22,15 +24,31 @@ function SettingsContent() {
     api.users.getUserByToken,
     user?.id ? { tokenIdentifier: user.id } : "skip"
   );
+  const userSettings = useQuery(api.users.getUserSettings);
+  const updateSettings = useMutation(api.users.updateUserSettings);
   const updateProfile = useMutation(api.users.updateUserProfile);
   const [instagram, setInstagram] = useState("");
   const [twitter, setTwitter] = useState("");
   const [website, setWebsite] = useState("");
+  const [prefs, setPrefs] = useState({
+    badge: true,
+    like: true,
+    comment: true,
+    product: true,
+    order: true,
+  });
+
+  useEffect(() => {
+    if (userSettings) {
+      setPrefs(userSettings.notificationPreferences);
+    }
+  }, [userSettings]);
 
   if (!currentUser) return null;
 
   const handleSave = async () => {
     await updateProfile({ instagram, twitter, website });
+    await updateSettings({ notificationPreferences: prefs });
   };
 
   return (
@@ -49,6 +67,59 @@ function SettingsContent() {
         <div className="space-y-2">
           <label className="block text-sm font-medium">Website</label>
           <Input value={website} onChange={(e) => setWebsite(e.target.value)} />
+        </div>
+        <h2 className="text-xl font-bold mt-6">Preferensi Notifikasi</h2>
+        <div className="space-y-2">
+          <div className="flex items-center gap-2">
+            <Switch
+              id="badge-toggle"
+              checked={prefs.badge}
+              onCheckedChange={(v) => setPrefs({ ...prefs, badge: v })}
+            />
+            <Label htmlFor="badge-toggle" className="text-sm">
+              Badge baru
+            </Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch
+              id="like-toggle"
+              checked={prefs.like}
+              onCheckedChange={(v) => setPrefs({ ...prefs, like: v })}
+            />
+            <Label htmlFor="like-toggle" className="text-sm">
+              Suka pada konten
+            </Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch
+              id="comment-toggle"
+              checked={prefs.comment}
+              onCheckedChange={(v) => setPrefs({ ...prefs, comment: v })}
+            />
+            <Label htmlFor="comment-toggle" className="text-sm">
+              Komentar baru
+            </Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch
+              id="product-toggle"
+              checked={prefs.product}
+              onCheckedChange={(v) => setPrefs({ ...prefs, product: v })}
+            />
+            <Label htmlFor="product-toggle" className="text-sm">
+              Update produk
+            </Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <Switch
+              id="order-toggle"
+              checked={prefs.order}
+              onCheckedChange={(v) => setPrefs({ ...prefs, order: v })}
+            />
+            <Label htmlFor="order-toggle" className="text-sm">
+              Status pesanan
+            </Label>
+          </div>
         </div>
         <Button onClick={handleSave}>Simpan</Button>
       </main>


### PR DESCRIPTION
## Summary
- support storing notification preferences via `updateUserSettings`
- expose current settings with `getUserSettings`
- allow users to toggle notification types in the settings page

## Testing
- `npm test` *(fails: forum and order unit tests, integration tests)*

------
https://chatgpt.com/codex/tasks/task_e_685cb66817d88327b8bb2807df8fafdc