### PR TITLE
Fix return object for getUserProfile

### DIFF
--- a/convex/users.ts
+++ b/convex/users.ts
@@ -307,7 +307,7 @@ export const getUserProfile = query({
       .unique();
 
     return {
-      ...user,
+      user,
       profile: profile || null,
     };
   },


### PR DESCRIPTION
## Summary
- ensure `getUserProfile` returns `user` object instead of spreading its fields

## Testing
- `npm run build`
- `npm test` *(fails: createTopic.handler is not a function, createOrder.handler is not a function, checkout test errors)*

------
https://chatgpt.com/codex/tasks/task_e_685cd9e606ec83278f2bdd284e8831b0