### PR TITLE
Add lesson notes support

### DIFF
--- a/convex/courses.ts
+++ b/convex/courses.ts
@@ -193,3 +193,57 @@ export const generateCertificate = mutation({
     return url;
   },
 });
+
+export const saveNote = mutation({
+  args: { lessonId: v.id("lessons"), note: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Login required");
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+      .unique();
+    if (!user) throw new Error("User not found");
+
+    const existing = await ctx.db
+      .query("lessonNotes")
+      .withIndex("by_user_lesson", (q) =>
+        q.eq("userId", user._id).eq("lessonId", args.lessonId)
+      )
+      .unique();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        note: args.note,
+        updatedAt: Date.now(),
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("lessonNotes", {
+      userId: user._id,
+      lessonId: args.lessonId,
+      note: args.note,
+      updatedAt: Date.now(),
+    });
+  },
+});
+
+export const getNote = query({
+  args: { lessonId: v.id("lessons") },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) return null;
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+      .unique();
+    if (!user) return null;
+    return await ctx.db
+      .query("lessonNotes")
+      .withIndex("by_user_lesson", (q) =>
+        q.eq("userId", user._id).eq("lessonId", args.lessonId)
+      )
+      .unique();
+  },
+});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -623,6 +623,15 @@ export default defineSchema({
     .index("by_user_course", ["userId", "courseId"])
     .index("by_user", ["userId"]),
 
+  lessonNotes: defineTable({
+    userId: v.id("users"),
+    lessonId: v.id("lessons"),
+    note: v.string(),
+    updatedAt: v.number(),
+  })
+    .index("by_user_lesson", ["userId", "lessonId"])
+    .index("by_user", ["userId"]),
+
   edits: defineTable({
     docType: v.string(), // "topic" or "comment"
     docId: v.string(),

--- a/src/pages/lesson.tsx
+++ b/src/pages/lesson.tsx
@@ -5,7 +5,8 @@ import LessonPlayer from "@/components/lesson-player";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
-import { useState } from "react";
+import { Textarea } from "@/components/ui/textarea";
+import { useState, useEffect } from "react";
 
 export default function LessonPage() {
   const { id } = useParams();
@@ -17,14 +18,37 @@ export default function LessonPage() {
     api.courses.getQuizQuestions,
     id ? { lessonId: id as any } : "skip"
   );
+  const savedNote = useQuery(
+    api.courses.getNote,
+    id ? { lessonId: id as any } : "skip"
+  );
+  const saveNote = useMutation(api.courses.saveNote);
   const submit = useMutation(api.courses.submitQuiz);
   const [answers, setAnswers] = useState<number[]>([]);
   const [score, setScore] = useState<number | null>(null);
+  const [note, setNote] = useState("");
+
+  useEffect(() => {
+    if (savedNote && savedNote.note !== undefined) {
+      setNote(savedNote.note);
+    }
+  }, [savedNote]);
 
   const handleSubmit = async () => {
     if (!id) return;
     const result = await submit({ lessonId: id as any, answers });
     setScore(result);
+  };
+
+  const handleSaveNote = async () => {
+    if (!id) return;
+    try {
+      await saveNote({ lessonId: id as any, note });
+      alert("Catatan disimpan");
+    } catch (err) {
+      console.error(err);
+      alert("Gagal menyimpan catatan");
+    }
   };
 
   if (lesson === undefined || questions === undefined) return <div>Loading...</div>;
@@ -33,36 +57,50 @@ export default function LessonPage() {
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
       <Navbar />
-      <main className="flex-grow container mx-auto px-4 py-8 space-y-6">
-        <h1 className="text-xl font-semibold">{lesson.title}</h1>
-        <LessonPlayer lessonId={lesson._id} />
-        {questions.length > 0 && (
-          <div className="space-y-4">
-            {questions.map((q, idx) => (
-              <div key={q._id} className="space-y-2">
-                <p>{q.question}</p>
-                {q.options.map((opt: string, i: number) => (
-                  <label key={i} className="block">
-                    <input
-                      type="radio"
-                      name={`q${idx}`}
-                      value={i}
-                      checked={answers[idx] === i}
-                      onChange={() => {
-                        const copy = [...answers];
-                        copy[idx] = i;
-                        setAnswers(copy);
-                      }}
-                    />{" "}
-                    {opt}
-                  </label>
+      <main className="flex-grow container mx-auto px-4 py-8">
+        <div className="flex gap-6">
+          <div className="flex-1 space-y-6">
+            <h1 className="text-xl font-semibold">{lesson.title}</h1>
+            <LessonPlayer lessonId={lesson._id} />
+            {questions.length > 0 && (
+              <div className="space-y-4">
+                {questions.map((q, idx) => (
+                  <div key={q._id} className="space-y-2">
+                    <p>{q.question}</p>
+                    {q.options.map((opt: string, i: number) => (
+                      <label key={i} className="block">
+                        <input
+                          type="radio"
+                          name={`q${idx}`}
+                          value={i}
+                          checked={answers[idx] === i}
+                          onChange={() => {
+                            const copy = [...answers];
+                            copy[idx] = i;
+                            setAnswers(copy);
+                          }}
+                        />{" "}
+                        {opt}
+                      </label>
+                    ))}
+                  </div>
                 ))}
+                <Button onClick={handleSubmit}>Kirim</Button>
+                {score !== null && <p>Skor: {score}</p>}
               </div>
-            ))}
-            <Button onClick={handleSubmit}>Kirim</Button>
-            {score !== null && <p>Skor: {score}</p>}
+            )}
           </div>
-        )}
+          <aside className="w-80 space-y-4">
+            <h2 className="text-lg font-semibold">Catatan</h2>
+            <Textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              className="neumorphic-input border-0 min-h-[200px] resize-none"
+              placeholder="Tulis catatan..."
+            />
+            <Button onClick={handleSaveNote}>Simpan</Button>
+          </aside>
+        </div>
       </main>
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- define new `lessonNotes` table in Convex schema
- implement `saveNote` and `getNote` mutations/queries
- add a notes sidebar to lesson page for writing personal notes

## Testing
- `npm test` *(fails: createOrder, createTopic, forumPosting, checkout tests)*

------
https://chatgpt.com/codex/tasks/task_e_685ce6b175788327ba98837d8180adfe