### PR TITLE
Add offline caching with service worker

### DIFF
--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,87 @@
+const CACHE_NAME = 'sensasi-cache-v1';
+const ASSETS_TO_CACHE = [
+  '/',
+  '/index.html',
+  '/tempo.jpg'
+];
+
+self.addEventListener('install', (event) => {
+  self.skipWaiting();
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS_TO_CACHE))
+  );
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) =>
+      Promise.all(
+        keys.map((key) => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+        })
+      )
+    )
+  );
+  self.clients.claim();
+});
+
+function notifyOffline() {
+  self.clients.matchAll().then((clients) => {
+    clients.forEach((client) =>
+      client.postMessage({ type: 'OFFLINE_CONTENT' })
+    );
+  });
+}
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+  if (request.method !== 'GET') return;
+
+  const url = new URL(request.url);
+  if (url.origin !== location.origin) return;
+
+  if (request.mode === 'navigate') {
+    event.respondWith(
+      fetch(request)
+        .then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          return response;
+        })
+        .catch(() =>
+          caches.match(request).then((cached) => {
+            if (cached) notifyOffline();
+            return cached;
+          })
+        )
+    );
+    return;
+  }
+
+  event.respondWith(
+    caches.match(request).then((cached) => {
+      if (cached) return cached;
+      return fetch(request)
+        .then((response) => {
+          const clone = response.clone();
+          caches.open(CACHE_NAME).then((cache) => cache.put(request, clone));
+          return response;
+        })
+        .catch(() => {
+          if (cached) notifyOffline();
+          return cached;
+        });
+    })
+  );
+});
+
+self.addEventListener('message', (event) => {
+  if (event.data && event.data.type === 'CACHE_URLS') {
+    const urls = event.data.urls;
+    event.waitUntil(
+      caches.open(CACHE_NAME).then((cache) => cache.addAll(urls))
+    );
+  }
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import Messages from "./pages/messages";
 import Settings from "./pages/settings";
 import { Toaster } from "@/components/ui/toaster";
 import NotificationListener from "@/components/notification-listener";
+import OfflineBanner from "@/components/offline-banner";
 import NotFound from "./pages/not-found";
 
 function App() {
@@ -89,6 +90,7 @@ function App() {
           <Route path="*" element={<NotFound />} />
         </Routes>
         {import.meta.env.VITE_TEMPO === "true" && useRoutes(routes)}
+        <OfflineBanner />
         <NotificationListener />
         <Toaster />
       </>

--- a/src/components/offline-banner.tsx
+++ b/src/components/offline-banner.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+export default function OfflineBanner() {
+  const [offline, setOffline] = useState(!navigator.onLine);
+
+  useEffect(() => {
+    const goOnline = () => setOffline(false);
+    const goOffline = () => setOffline(true);
+    window.addEventListener('online', goOnline);
+    window.addEventListener('offline', goOffline);
+
+    navigator.serviceWorker?.addEventListener('message', (event) => {
+      if (event.data && event.data.type === 'OFFLINE_CONTENT') {
+        setOffline(true);
+      }
+    });
+
+    return () => {
+      window.removeEventListener('online', goOnline);
+      window.removeEventListener('offline', goOffline);
+    };
+  }, []);
+
+  if (!offline) return null;
+
+  return (
+    <div className="bg-yellow-400 text-black text-center py-1 text-sm">
+      Anda sedang offline - konten mungkin berasal dari cache.
+    </div>
+  );
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -24,6 +24,12 @@ if (!PUBLISHABLE_KEY) {
   throw new Error("Missing Publishable Key");
 }
 
+if ('serviceWorker' in navigator) {
+  window.addEventListener('load', () => {
+    navigator.serviceWorker.register('/service-worker.js').catch(console.error);
+  });
+}
+
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <ClerkProvider

--- a/src/pages/forum.tsx
+++ b/src/pages/forum.tsx
@@ -330,6 +330,12 @@ export default function Forum() {
       toast({
         title: bookmarked ? "Ditambahkan ke koleksi" : "Dihapus dari koleksi",
       });
+      if (bookmarked && navigator.serviceWorker?.controller) {
+        navigator.serviceWorker.controller.postMessage({
+          type: "CACHE_URLS",
+          urls: [`/forum?topic=${topicId}`],
+        });
+      }
     } catch (error) {
       console.error("Error toggling bookmark:", error);
       toast({


### PR DESCRIPTION
## Summary
- add new service worker in `public/` to cache static assets and bookmarked threads
- show offline banner when app is offline or content is served from cache
- register the service worker
- pre-cache bookmarked threads when bookmarking

## Testing
- `npm test --silent` *(fails: createTopic.handler is not a function and others)*

------
https://chatgpt.com/codex/tasks/task_e_685ce8e968f48327825622f9445335c4