### PR TITLE
Add leaderboard page and top contributors query

### DIFF
--- a/convex/rewards.ts
+++ b/convex/rewards.ts
@@ -13,3 +13,20 @@ export const getUserRewards = query({
     return { tier, discount, exclusiveAccess };
   },
 });
+
+export const getTopContributors = query({
+  args: { limit: v.optional(v.number()) },
+  handler: async (ctx, args) => {
+    const users = await ctx.db.query("users").collect();
+    users.sort(
+      (a, b) => (b.contributionPoints ?? 0) - (a.contributionPoints ?? 0),
+    );
+    const limit = args.limit ?? 50;
+    return users.slice(0, limit).map((u) => ({
+      _id: u._id,
+      name: u.name,
+      image: u.image,
+      contributionPoints: u.contributionPoints ?? 0,
+    }));
+  },
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ import OrderReviewPage from "./pages/order-review";
 import OrderDetail from "./pages/order-detail";
 import MarketplaceCheckout from "./pages/marketplace-checkout";
 import Messages from "./pages/messages";
+import Leaderboard from "./pages/leaderboard";
 
 import Settings from "./pages/settings";
 import { Toaster } from "@/components/ui/toaster";
@@ -54,6 +55,7 @@ function App() {
           <Route path="/settings" element={<Settings />} />
           <Route path="/messages" element={<Messages />} />
           <Route path="/collections" element={<Collections />} />
+          <Route path="/leaderboard" element={<Leaderboard />} />
           <Route path="/marketplace" element={<Marketplace />} />
           <Route
             path="/marketplace/product/:id"

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -146,6 +146,25 @@ export function Navbar() {
               </svg>
               Database
             </Link>
+            <Link
+              to="/leaderboard"
+              className="neumorphic-button-sm inline-flex items-center px-4 py-2 text-sm font-medium text-[#1D1D1F] bg-transparent transition-all duration-200 border-0 shadow-none hover:scale-105 active:scale-95"
+            >
+              <svg
+                className="w-4 h-4 mr-1.5"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={1.5}
+                  d="M12 8l3 8H9l3-8z"
+                />
+              </svg>
+              Leaderboard
+            </Link>
             <Button
               onClick={handleDashboard}
               className="neumorphic-button-sm inline-flex items-center px-4 py-2 text-sm font-medium text-[#1D1D1F] bg-transparent transition-all duration-200 border-0 shadow-none hover:scale-105 active:scale-95"
@@ -288,6 +307,27 @@ export function Navbar() {
                     Database
                   </Link>
                 </DropdownMenuItem>
+                <DropdownMenuItem asChild>
+                  <Link
+                    to="/leaderboard"
+                    className="flex items-center px-2 py-2 text-[#1D1D1F] hover:bg-[#F5F5F7] rounded-lg transition-colors"
+                  >
+                    <svg
+                      className="w-4 h-4 mr-2"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M12 8l3 8H9l3-8z"
+                      />
+                    </svg>
+                    Leaderboard
+                  </Link>
+                </DropdownMenuItem>
                 <DropdownMenuItem onClick={handleDashboard}>
                   <div className="flex items-center px-2 py-2 text-[#1D1D1F] hover:bg-[#F5F5F7] rounded-lg transition-colors">
                     <svg
@@ -397,6 +437,12 @@ export function Navbar() {
                         className="neumorphic-button-sm w-full text-left"
                       >
                         Database
+                      </Link>
+                      <Link
+                        to="/leaderboard"
+                        className="neumorphic-button-sm w-full text-left"
+                      >
+                        Leaderboard
                       </Link>
                       <Button
                         onClick={handleDashboard}

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -1,0 +1,57 @@
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Link } from "react-router-dom";
+
+export default function Leaderboard() {
+  const contributors = useQuery(api.rewards.getTopContributors, {});
+
+  const getInitials = (name: string | undefined | null) => {
+    if (!name) return "U";
+    return name
+      .split(" ")
+      .map((n) => n[0])
+      .join("")
+      .toUpperCase()
+      .slice(0, 2);
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <Navbar />
+      <main className="flex-grow container mx-auto px-4 py-16">
+        <h1 className="text-3xl font-bold text-center mb-8">Leaderboard</h1>
+        {!contributors ? (
+          <p className="text-center text-[#86868B]">Loading...</p>
+        ) : contributors.length === 0 ? (
+          <p className="text-center text-[#86868B]">Belum ada data.</p>
+        ) : (
+          <div className="space-y-4 max-w-xl mx-auto">
+            {contributors.map((u, idx) => (
+              <Link
+                to={`/u/${u._id}`}
+                key={u._id}
+                className="neumorphic-card p-4 flex items-center gap-4 hover:scale-[1.02] transition"
+              >
+                <span className="font-bold text-xl w-6 text-center">{idx + 1}</span>
+                <Avatar className="w-10 h-10">
+                  <AvatarImage src={u.image || undefined} />
+                  <AvatarFallback>{getInitials(u.name)}</AvatarFallback>
+                </Avatar>
+                <div className="flex-1">
+                  <h2 className="font-semibold text-[#1D1D1F]">{u.name || "Pengguna"}</h2>
+                </div>
+                <div className="font-medium text-sm">
+                  {u.contributionPoints} pts
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </main>
+      <Footer />
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- query top contributors from rewards functions
- implement a Leaderboard page displaying rankings
- expose leaderboard route in the app
- link leaderboard from the navigation menu

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cee5069688327963a5d5517e959da