### PR TITLE
Implement shipment tracking

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -217,6 +217,16 @@ export default defineSchema({
     .index("by_order_status", ["orderStatus"])
     .index("by_created_at", ["createdAt"]),
 
+  orderTracking: defineTable({
+    orderId: v.id("orders"),
+    manifestCode: v.optional(v.string()),
+    description: v.string(),
+    cityName: v.optional(v.string()),
+    manifestDate: v.string(),
+    manifestTime: v.string(),
+    createdAt: v.number(),
+  }).index("by_order", ["orderId"]),
+
   reviews: defineTable({
     orderId: v.id("orders"),
     productId: v.id("products"),

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useQuery, useMutation } from "convex/react";
+import { useQuery, useMutation, useAction } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Navbar } from "@/components/navbar";
 import { Footer } from "@/components/footer";
@@ -93,6 +93,7 @@ function AdminContent() {
 
   const verifyPayment = useMutation(api.marketplace.verifyOrderPayment);
   const updateStatus = useMutation(api.marketplace.updateOrderStatus);
+  const trackShipment = useAction(api.marketplace.trackShipment);
   const updateUserRole = useMutation(api.users.updateUserRole);
   const suspendUser = useMutation(api.admin.suspendUser);
   const deleteUser = useMutation(api.admin.deleteUser);
@@ -1078,18 +1079,29 @@ function AdminContent() {
                                   </Button>
                                 )}
                                 {order.orderStatus === "shipped" && (
-                                  <Button
-                                    size="sm"
-                                    className="neumorphic-button-sm h-8 px-3 text-xs"
-                                    onClick={async () => {
-                                      await updateStatus({
-                                        orderId: order._id,
-                                        status: "delivered",
-                                      });
-                                    }}
-                                  >
-                                    Selesai
-                                  </Button>
+                                  <>
+                                    <Button
+                                      size="sm"
+                                      className="neumorphic-button-sm h-8 px-3 text-xs"
+                                      onClick={async () => {
+                                        await trackShipment({ orderId: order._id });
+                                      }}
+                                    >
+                                      Refresh
+                                    </Button>
+                                    <Button
+                                      size="sm"
+                                      className="neumorphic-button-sm h-8 px-3 text-xs"
+                                      onClick={async () => {
+                                        await updateStatus({
+                                          orderId: order._id,
+                                          status: "delivered",
+                                        });
+                                      }}
+                                    >
+                                      Selesai
+                                    </Button>
+                                  </>
                                 )}
                               </div>
                             </TableCell>

--- a/src/pages/order-detail.tsx
+++ b/src/pages/order-detail.tsx
@@ -26,6 +26,10 @@ function OrderDetailContent() {
     api.marketplace.getOrderById,
     orderId ? { orderId: orderId as any } : "skip",
   );
+  const tracking = useQuery(
+    api.marketplace.getOrderTracking,
+    order && order.trackingNumber ? { orderId: order._id } : "skip",
+  );
   if (order === undefined || currentUser === undefined) return <div>Loading...</div>;
   if (order === null) return <div>Order tidak ditemukan</div>;
   if (currentUser && currentUser._id !== order.buyerId && currentUser._id !== order.sellerId) {
@@ -72,6 +76,24 @@ function OrderDetailContent() {
             {order.trackingNumber && <p>Resi: {order.trackingNumber}</p>}
           </CardContent>
         </Card>
+
+        {order.trackingNumber && tracking && (
+          <Card className="neumorphic-card border-0">
+            <CardHeader>
+              <CardTitle>Riwayat Pengiriman</CardTitle>
+            </CardHeader>
+            <CardContent className="text-sm space-y-1">
+              <ul className="space-y-1">
+                {tracking.map((t: any, idx: number) => (
+                  <li key={idx}>
+                    {t.manifestDate} {t.manifestTime} - {t.description}
+                    {t.cityName ? ` (${t.cityName})` : ""}
+                  </li>
+                ))}
+              </ul>
+            </CardContent>
+          </Card>
+        )}
 
         {order.paymentProofUrl && (
           <Card className="neumorphic-card border-0">


### PR DESCRIPTION
## Summary
- extend Convex schema with `orderTracking`
- add tracking event persistence and retrieval in marketplace logic
- show tracking history on order detail pages
- let admins refresh shipment tracking

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cf6fe5de483279611cadf6ba227f3