### PR TITLE
Implement order expiry and weekly leaderboard

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -17,6 +17,7 @@ import type * as admin from "../admin.js";
 import type * as bookmarks from "../bookmarks.js";
 import type * as certificates from "../certificates.js";
 import type * as courses from "../courses.js";
+import type * as crons from "../crons.js";
 import type * as follows from "../follows.js";
 import type * as forum from "../forum.js";
 import type * as marketplace from "../marketplace.js";
@@ -40,6 +41,7 @@ declare const fullApi: ApiFromModules<{
   bookmarks: typeof bookmarks;
   certificates: typeof certificates;
   courses: typeof courses;
+  crons: typeof crons;
   follows: typeof follows;
   forum: typeof forum;
   marketplace: typeof marketplace;

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -1,0 +1,18 @@
+import { cronJobs } from "convex/server";
+import { internal } from "./_generated/api";
+
+const crons = cronJobs();
+
+crons.daily(
+  "expire-unpaid-orders",
+  { hourUTC: 0, minuteUTC: 0 },
+  internal.marketplace.expireUnpaidOrders,
+);
+
+crons.weekly(
+  "update-weekly-leaderboard",
+  { dayOfWeek: "monday", hourUTC: 0, minuteUTC: 5 },
+  internal.rewards.updateWeeklyLeaderboard,
+);
+
+export default crons;

--- a/convex/forum.ts
+++ b/convex/forum.ts
@@ -483,6 +483,7 @@ export const createTopic = mutation({
 
     await ctx.db.patch(user._id, {
       contributionPoints: newPoints,
+      weeklyContributionPoints: (user.weeklyContributionPoints ?? 0) + 10,
       badges: newBadges,
     });
 
@@ -775,6 +776,7 @@ export const createComment = mutation({
 
     await ctx.db.patch(user._id, {
       contributionPoints: newPoints,
+      weeklyContributionPoints: (user.weeklyContributionPoints ?? 0) + 2,
       badges: newBadges,
     });
 

--- a/convex/rewards.ts
+++ b/convex/rewards.ts
@@ -1,5 +1,5 @@
 import { v } from "convex/values";
-import { query } from "./_generated/server";
+import { query, internalMutation } from "./_generated/server";
 
 export const getUserRewards = query({
   args: { userId: v.id("users") },
@@ -14,19 +14,64 @@ export const getUserRewards = query({
   },
 });
 
+const weekStart = (ts: number) => {
+  const d = new Date(ts);
+  d.setUTCHours(0, 0, 0, 0);
+  d.setUTCDate(d.getUTCDate() - d.getUTCDay());
+  return d.getTime();
+};
+
 export const getTopContributors = query({
-  args: { limit: v.optional(v.number()) },
+  args: { limit: v.optional(v.number()), period: v.optional(v.string()) },
   handler: async (ctx, args) => {
+    const limit = args.limit ?? 50;
+    if (args.period === "weekly") {
+      const entries = await ctx.db
+        .query("weeklyLeaderboard")
+        .withIndex("by_week", (q) => q.eq("weekStart", weekStart(Date.now())))
+        .collect();
+      entries.sort((a, b) => b.points - a.points);
+      return entries.slice(0, limit).map((e) => ({
+        _id: e.userId,
+        name: e.name,
+        image: e.image,
+        contributionPoints: e.points,
+      }));
+    }
     const users = await ctx.db.query("users").collect();
     users.sort(
       (a, b) => (b.contributionPoints ?? 0) - (a.contributionPoints ?? 0),
     );
-    const limit = args.limit ?? 50;
     return users.slice(0, limit).map((u) => ({
       _id: u._id,
       name: u.name,
       image: u.image,
       contributionPoints: u.contributionPoints ?? 0,
     }));
+  },
+});
+
+export const updateWeeklyLeaderboard = internalMutation({
+  handler: async (ctx) => {
+    const allUsers = await ctx.db.query("users").collect();
+    const start = weekStart(Date.now());
+    allUsers.sort(
+      (a, b) => (b.weeklyContributionPoints ?? 0) - (a.weeklyContributionPoints ?? 0),
+    );
+    const top = allUsers.slice(0, 50);
+    for (const u of top) {
+      await ctx.db.insert("weeklyLeaderboard", {
+        weekStart: start,
+        userId: u._id,
+        name: u.name,
+        image: u.image,
+        points: u.weeklyContributionPoints ?? 0,
+      });
+    }
+    for (const u of allUsers) {
+      if ((u.weeklyContributionPoints ?? 0) !== 0) {
+        await ctx.db.patch(u._id, { weeklyContributionPoints: 0 });
+      }
+    }
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -9,6 +9,7 @@ export default defineSchema({
     tokenIdentifier: v.string(),
     role: v.string(),
     contributionPoints: v.number(),
+    weeklyContributionPoints: v.number(),
     badges: v.array(v.string()),
     experiencePoints: v.number(), // Baru: Poin pengalaman untuk leveling
     level: v.number(),            // Baru: Level pengguna
@@ -671,4 +672,14 @@ export default defineSchema({
     previousContent: v.string(),
     createdAt: v.number(),
   }).index("by_doc", ["docType", "docId"]),
+
+  weeklyLeaderboard: defineTable({
+    weekStart: v.number(),
+    userId: v.id("users"),
+    name: v.optional(v.string()),
+    image: v.optional(v.string()),
+    points: v.number(),
+  })
+    .index("by_week", ["weekStart"])
+    .index("by_week_points", ["weekStart", "points"]),
 });

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -71,6 +71,9 @@ export const createOrUpdateUser = mutation({
       if (existingUser.contributionPoints === undefined) {
         patch.contributionPoints = 0;
       }
+      if (existingUser.weeklyContributionPoints === undefined) {
+        patch.weeklyContributionPoints = 0;
+      }
       if (existingUser.badges === undefined) {
         patch.badges = [];
       }
@@ -162,6 +165,7 @@ export const createOrUpdateUser = mutation({
       tokenIdentifier: identity.subject,
       role: args.role ?? "buyer",
       contributionPoints: 0,
+      weeklyContributionPoints: 0,
       badges: [],
       experiencePoints: 0,
       level: 1,

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -3,10 +3,12 @@ import { Footer } from "@/components/footer";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 
 export default function Leaderboard() {
-  const contributors = useQuery(api.rewards.getTopContributors, {});
+  const [params] = useSearchParams();
+  const period = params.get("period") ?? undefined;
+  const contributors = useQuery(api.rewards.getTopContributors, { period });
 
   const getInitials = (name: string | undefined | null) => {
     if (!name) return "U";


### PR DESCRIPTION
## Summary
- add weeklyContributionPoints tracking in schema and user logic
- snapshot weekly leaderboard and reset counts
- expire unpaid orders daily and restore product stock
- schedule jobs via new `crons.ts`
- support weekly leaderboard view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d09e5c23c8327aa962e4b47e7e2d0