### PR TITLE
Fix build failure in profile page

### DIFF
--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -185,10 +185,10 @@ function ProfileContent() {
   );
 
   const contributionPoints =
-    pointStats?.contributionPoints ?? profileData?.user.contributionPoints || 0;
+    pointStats?.contributionPoints ?? profileData?.user.contributionPoints ?? 0;
   const level = pointStats?.level ?? Math.floor(contributionPoints / 100) + 1;
   const progressPercentage = contributionPoints % 100;
-  const badges = pointStats?.badges ?? profileData?.user.badges || [];
+  const badges = pointStats?.badges ?? profileData?.user.badges ?? [];
 
   const getUserBadge = () => {
     const posts = userTopics?.length || 0;


### PR DESCRIPTION
## Summary
- resolve TypeScript error when mixing `||` and `??`
- always fall back to defaults using nullish coalescing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685d56ddc7848327bdf7a969b8ac2447