### PR TITLE
Add advanced course seeding and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,13 @@ _Versi dokumen: 1.1.0 (Updated: Juni 2025)_
 
 ## Development Seeds
 
-Populate your Convex deployment with sample marketplace data using:
+Populate your Convex deployment with sample marketplace and course data using:
 
 ```bash
 CONVEX_URL=<your_convex_url> npx ts-node scripts/seed.ts
 ```
 
-The command calls `api.marketplace.initializeSampleData` to insert starter brands, perfumers and fragrances for local testing.
+The command now calls both `api.marketplace.initializeSampleData` and `api.courses.initializeAdvancedModules` to insert starter marketplace records and an advanced course with lessons and quizzes.
 
 ## Running Tests
 

--- a/convex/courses.ts
+++ b/convex/courses.ts
@@ -247,3 +247,75 @@ export const getNote = query({
       .unique();
   },
 });
+
+// Seed advanced course modules with lessons and quizzes
+export const initializeAdvancedModules = mutation({
+  handler: async (ctx) => {
+    const now = Date.now();
+
+    const courseId = await ctx.db.insert("courses", {
+      title: "Advanced Perfumery",
+      description: "Pendalaman teknik formulasi parfum lanjutan",
+      category: "perfumery",
+      level: "advanced",
+      image:
+        "https://images.unsplash.com/photo-1512427691650-dbd6a56d1e21?w=400&q=80",
+      instructor: "Dr. Aroma",
+      createdAt: now,
+      updatedAt: now,
+    });
+
+    const lessons = [
+      { title: "Layering Fragrance", videoUrl: "https://example.com/video1.mp4" },
+      { title: "Stability & Safety", videoUrl: "https://example.com/video2.mp4" },
+    ];
+
+    const lessonIds: Id<"lessons">[] = [];
+    for (let i = 0; i < lessons.length; i++) {
+      const id = await ctx.db.insert("lessons", {
+        courseId,
+        title: lessons[i].title,
+        videoUrl: lessons[i].videoUrl,
+        order: i + 1,
+        createdAt: now,
+        updatedAt: now,
+      });
+      lessonIds.push(id);
+    }
+
+    const quizzes = [
+      {
+        lessonIndex: 0,
+        question: "Apa tujuan teknik layering?",
+        options: [
+          "Memadukan aroma menjadi komposisi unik",
+          "Mengurangi biaya produksi",
+          "Menambah kadar alkohol",
+        ],
+        correctOption: 0,
+      },
+      {
+        lessonIndex: 1,
+        question: "Stability test dilakukan untuk?",
+        options: [
+          "Mengetahui ketahanan formula",
+          "Menentukan warna botol",
+          "Meningkatkan marketing",
+        ],
+        correctOption: 0,
+      },
+    ];
+
+    for (const q of quizzes) {
+      await ctx.db.insert("quizzes", {
+        lessonId: lessonIds[q.lessonIndex],
+        question: q.question,
+        options: q.options,
+        correctOption: q.correctOption,
+        createdAt: now,
+      });
+    }
+
+    return { courseId, lessons: lessonIds.length, quizzes: quizzes.length };
+  },
+});

--- a/planning/KURSUS/PRD.md
+++ b/planning/KURSUS/PRD.md
@@ -45,3 +45,8 @@ flowchart TD
 - Nilai rata-rata peserta
 - Kepuasan pembelajaran (survey)
 - Rasio rekomendasi kursus
+
+### 7. Modul Lanjutan
+
+Script seed sekarang menambahkan kursus "Advanced Perfumery" lengkap dengan dua
+lesson dan kuis. Modul ini dipakai untuk pengujian fitur progres lanjutan.

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -11,11 +11,15 @@ const client = new ConvexHttpClient(convexUrl);
 
 async function main() {
   try {
-    const result = await client.mutation(
+    const marketplace = await client.mutation(
       api.marketplace.initializeSampleData,
       {},
     );
-    console.log(result);
+    const courses = await client.mutation(
+      api.courses.initializeAdvancedModules,
+      {},
+    );
+    console.log({ marketplace, courses });
   } catch (err: any) {
     console.error("Failed to seed sample data:", err.message);
     process.exit(1);

--- a/tests/unit/courseProgress.test.ts
+++ b/tests/unit/courseProgress.test.ts
@@ -1,0 +1,32 @@
+import { getCourseProgress } from '../../convex/progress';
+
+describe('course progress', () => {
+  it('returns progress records for course lessons', async () => {
+    const user = { _id: 'u1' };
+    const lessons = [{ _id: 'l1' }, { _id: 'l2' }];
+    const progressData = [
+      { lessonId: 'l1', userId: 'u1', progress: 100, completed: true },
+      { lessonId: 'l2', userId: 'u1', progress: 50, completed: false },
+    ];
+
+    const ctx = {
+      auth: { getUserIdentity: jest.fn().mockResolvedValue({ subject: 't' }) },
+      db: {
+        query: jest
+          .fn()
+          .mockReturnValueOnce({
+            withIndex: () => ({ unique: jest.fn().mockResolvedValue(user) }),
+          })
+          .mockReturnValueOnce({
+            withIndex: () => ({ collect: jest.fn().mockResolvedValue(lessons) }),
+          })
+          .mockReturnValue({
+            withIndex: () => ({ collect: jest.fn().mockResolvedValue(progressData) }),
+          }),
+      },
+    } as any;
+
+    const result = await getCourseProgress._handler(ctx, { courseId: 'c1' } as any);
+    expect(result).toEqual(progressData);
+  });
+});


### PR DESCRIPTION
## Summary
- seed advanced course modules with lessons and quizzes
- extend sample seed script to initialize advanced modules
- document new seeding capability in README and course PRD
- add unit test covering course progress queries

## Testing
- `npm test tests/unit --silent`
- `npm test tests/integration --silent`


------
https://chatgpt.com/codex/tasks/task_e_685d64613e8483279b9667944d6f7158