### PR TITLE
Add price field to advanced course seed

### DIFF
--- a/convex/courses.ts
+++ b/convex/courses.ts
@@ -258,6 +258,7 @@ export const initializeAdvancedModules = mutation({
       description: "Pendalaman teknik formulasi parfum lanjutan",
       category: "perfumery",
       level: "advanced",
+      price: 0,
       image:
         "https://images.unsplash.com/photo-1512427691650-dbd6a56d1e21?w=400&q=80",
       instructor: "Dr. Aroma",


### PR DESCRIPTION
## Summary
- add missing `price` field when seeding advanced course modules

## Testing
- `node node_modules/jest/bin/jest.js` *(fails: Cannot find module 'jest/bin/jest.js')*

------
https://chatgpt.com/codex/tasks/task_e_685d7594e18083278288dbeca5a31139