### PR TITLE
Add report voting and moderation queue

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -123,6 +123,16 @@ export default defineSchema({
     .index("by_reporter", ["reporterId"])
     .index("by_topic_reporter", ["topicId", "reporterId"]),
 
+  reportVotes: defineTable({
+    reportId: v.id("topicReports"),
+    userId: v.id("users"),
+    value: v.number(),
+    createdAt: v.number(),
+  })
+    .index("by_report", ["reportId"])
+    .index("by_user", ["userId"])
+    .index("by_report_user", ["reportId", "userId"]),
+
   products: defineTable({
     title: v.string(),
     description: v.string(),

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -89,7 +89,7 @@ function AdminContent() {
   const forumStats = useQuery(api.forum.getForumStats);
   const systemHealth = useQuery(api.admin.getSystemHealth);
   const platformAnalytics = useQuery(api.admin.getPlatformAnalytics);
-  const pendingReports = useQuery(api.admin.getPendingReports);
+  const pendingReports = useQuery(api.forum.getTopReports);
 
   const verifyPayment = useMutation(api.marketplace.verifyOrderPayment);
   const updateStatus = useMutation(api.marketplace.updateOrderStatus);
@@ -108,7 +108,7 @@ function AdminContent() {
     totalPosts:
       (platformAnalytics?.topicCount || 0) +
       (platformAnalytics?.commentCount || 0),
-    pendingReports: platformAnalytics?.pendingReports || 0,
+    pendingReports: pendingReports?.length || 0,
     activeDiscussions: forumStats?.activeToday || 0,
     systemUptime: systemHealth?.uptime || "99.9%",
     memoryUsage: systemHealth?.memoryUsage || "0%",
@@ -365,7 +365,7 @@ function AdminContent() {
                       </TableHead>
                       <TableHead className="text-[#1D1D1F]">Konten</TableHead>
                       <TableHead className="text-[#1D1D1F]">Pelapor</TableHead>
-                      <TableHead className="text-[#1D1D1F]">Status</TableHead>
+                      <TableHead className="text-[#1D1D1F]">Suara</TableHead>
                       <TableHead className="text-[#1D1D1F]">Aksi</TableHead>
                     </TableRow>
                   </TableHeader>
@@ -381,23 +381,8 @@ function AdminContent() {
                         <TableCell className="text-[#86868B]">
                           {report.reporter}
                         </TableCell>
-                        <TableCell>
-                          <Badge
-                            variant={
-                              report.status === "pending"
-                                ? "destructive"
-                                : "default"
-                            }
-                            className={
-                              report.status === "pending"
-                                ? "bg-yellow-100 text-yellow-800"
-                                : "bg-green-100 text-green-800"
-                            }
-                          >
-                            {report.status === "pending"
-                              ? "Pending"
-                              : "Selesai"}
-                          </Badge>
+                        <TableCell className="text-center text-[#1D1D1F]">
+                          {report.votes}
                         </TableCell>
                         <TableCell>
                           <div className="flex space-x-2">
@@ -408,24 +393,6 @@ function AdminContent() {
                               <Eye className="w-3 h-3 mr-1" />
                               Lihat
                             </Button>
-                            {report.status === "pending" && (
-                              <>
-                                <Button
-                                  size="sm"
-                                  className="neumorphic-button-sm h-8 px-3 text-xs text-green-600"
-                                >
-                                  <CheckCircle className="w-3 h-3 mr-1" />
-                                  Setuju
-                                </Button>
-                                <Button
-                                  size="sm"
-                                  className="neumorphic-button-sm h-8 px-3 text-xs text-red-600"
-                                >
-                                  <XCircle className="w-3 h-3 mr-1" />
-                                  Tolak
-                                </Button>
-                              </>
-                            )}
                           </div>
                         </TableCell>
                       </TableRow>

--- a/tests/unit/reportVoting.test.ts
+++ b/tests/unit/reportVoting.test.ts
@@ -1,0 +1,42 @@
+import { voteReport, getTopReports } from '../../convex/forum';
+
+describe('report voting', () => {
+  it('requires auth to vote', async () => {
+    const ctx = { auth: { getUserIdentity: jest.fn().mockResolvedValue(null) } } as any;
+    await expect(
+      voteReport._handler(ctx, { reportId: 'r1' as any, value: 1 })
+    ).rejects.toThrow('Anda harus login');
+  });
+
+  it('returns reports sorted by votes', async () => {
+    const reports = [
+      { _id: 'r1', topicId: 't1', reporterId: 'u2', reason: 'spam', createdAt: 1 },
+      { _id: 'r2', topicId: 't1', reporterId: 'u3', reason: 'off', createdAt: 2 },
+    ];
+    const votes = [
+      { reportId: 'r1', userId: 'u3', value: 1 },
+      { reportId: 'r1', userId: 'u4', value: 1 },
+      { reportId: 'r2', userId: 'u3', value: 1 },
+    ];
+    const topics = [{ _id: 't1', title: 'Topic' }];
+    const users = [
+      { _id: 'u2', name: 'A' },
+      { _id: 'u3', name: 'B' },
+      { _id: 'u4', name: 'C' },
+    ];
+    const ctx = {
+      db: {
+        query: jest
+          .fn()
+          .mockReturnValueOnce({ collect: jest.fn().mockResolvedValue(reports) })
+          .mockReturnValueOnce({ collect: jest.fn().mockResolvedValue(votes) })
+          .mockReturnValueOnce({ collect: jest.fn().mockResolvedValue(topics) })
+          .mockReturnValueOnce({ collect: jest.fn().mockResolvedValue(users) }),
+      },
+    } as any;
+
+    const res = await getTopReports._handler(ctx, { limit: undefined } as any);
+    expect(res[0].id).toBe('r1');
+    expect(res[0].votes).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- track votes on topic reports via new `reportVotes` table
- support voting on reports and viewing top reports in Convex forum logic
- show moderator queue sorted by vote counts in admin page
- test report voting and queue retrieval logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d7add5f488327bf6a291c6ca32d97