### PR TITLE
Add user moderation tools

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -17,6 +17,8 @@ export default defineSchema({
     createdAt: v.number(),
     reviewCount: v.number(),
     helpfulCount: v.number(),
+    warnings: v.number(),
+    bannedUntil: v.number(),
   }).index("by_token", ["tokenIdentifier"]),
 
   categories: defineTable({

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -95,6 +95,12 @@ export const createOrUpdateUser = mutation({
       if (existingUser.helpfulCount === undefined) {
         patch.helpfulCount = 0;
       }
+      if (existingUser.warnings === undefined) {
+        patch.warnings = 0;
+      }
+      if (existingUser.bannedUntil === undefined) {
+        patch.bannedUntil = 0;
+      }
       if (Object.keys(patch).length > 0) {
         await ctx.db.patch(existingUser._id, patch);
       }
@@ -173,6 +179,8 @@ export const createOrUpdateUser = mutation({
       createdAt: Date.now(),
       reviewCount: 0,
       helpfulCount: 0,
+      warnings: 0,
+      bannedUntil: 0,
     });
     await ctx.db.insert("userProfiles", {
       userId,

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -97,6 +97,9 @@ function AdminContent() {
   const updateUserRole = useMutation(api.users.updateUserRole);
   const suspendUser = useMutation(api.admin.suspendUser);
   const deleteUser = useMutation(api.admin.deleteUser);
+  const issueWarning = useMutation(api.admin.issueWarning);
+  const tempBanUser = useMutation(api.admin.tempBanUser);
+  const permBanUser = useMutation(api.admin.permBanUser);
   const broadcastMessage = useMutation(api.admin.broadcastSystemMessage);
   const clearCache = useMutation(api.admin.clearSystemCache);
   const backupDatabase = useMutation(api.admin.backupDatabase);
@@ -421,6 +424,8 @@ function AdminContent() {
                       <TableHead className="text-[#1D1D1F]">Email</TableHead>
                       <TableHead className="text-[#1D1D1F]">Role</TableHead>
                       <TableHead className="text-[#1D1D1F]">Poin</TableHead>
+                      <TableHead className="text-[#1D1D1F]">Peringatan</TableHead>
+                      <TableHead className="text-[#1D1D1F]">Banned Sampai</TableHead>
                       <TableHead className="text-[#1D1D1F]">
                         Bergabung
                       </TableHead>
@@ -454,6 +459,18 @@ function AdminContent() {
                         </TableCell>
                         <TableCell className="text-[#86868B]">
                           {user.contributionPoints || 0}
+                        </TableCell>
+                        <TableCell className="text-[#86868B]">
+                          {user.warnings || 0}
+                        </TableCell>
+                        <TableCell className="text-[#86868B]">
+                          {user.bannedUntil
+                            ? user.bannedUntil === -1
+                              ? "Permanent"
+                              : new Date(user.bannedUntil).toLocaleDateString(
+                                  "id-ID",
+                                )
+                            : "-"}
                         </TableCell>
                         <TableCell className="text-[#86868B]">
                           {user.createdAt
@@ -526,6 +543,44 @@ function AdminContent() {
                                 </AlertDialogFooter>
                               </AlertDialogContent>
                             </AlertDialog>
+                            <Button
+                              size="sm"
+                              className="neumorphic-button-sm h-8 px-3 text-xs text-yellow-600"
+                              onClick={async () => {
+                                await issueWarning({ userId: user._id });
+                              }}
+                            >
+                              <AlertTriangle className="w-3 h-3 mr-1" />
+                              Warning
+                            </Button>
+                            <Button
+                              size="sm"
+                              className="neumorphic-button-sm h-8 px-3 text-xs text-orange-600"
+                              onClick={async () => {
+                                const days = parseInt(
+                                  prompt('Ban berapa hari?') || '0',
+                                  10,
+                                );
+                                if (days > 0) {
+                                  await tempBanUser({ userId: user._id, days });
+                                }
+                              }}
+                            >
+                              <Ban className="w-3 h-3 mr-1" />
+                              Temp Ban
+                            </Button>
+                            <Button
+                              size="sm"
+                              className="neumorphic-button-sm h-8 px-3 text-xs text-red-800"
+                              onClick={async () => {
+                                if (confirm('Ban permanen?')) {
+                                  await permBanUser({ userId: user._id });
+                                }
+                              }}
+                            >
+                              <XCircle className="w-3 h-3 mr-1" />
+                              Ban
+                            </Button>
                           </div>
                         </TableCell>
                       </TableRow>

--- a/tests/unit/adminModeration.test.ts
+++ b/tests/unit/adminModeration.test.ts
@@ -1,0 +1,48 @@
+import { issueWarning, tempBanUser, permBanUser } from '../../convex/admin';
+
+const createAdminCtx = () => ({
+  auth: { getUserIdentity: jest.fn().mockResolvedValue({ subject: 'admin' }) },
+  db: {
+    query: jest.fn().mockReturnValue({
+      withIndex: () => ({ unique: jest.fn().mockResolvedValue({ _id: 'a1', role: 'admin' }) })
+    }),
+    get: jest.fn().mockResolvedValue({ _id: 'u1', warnings: 0, bannedUntil: 0, role: 'buyer' }),
+    patch: jest.fn(),
+  },
+});
+
+const createUserCtx = () => ({
+  auth: { getUserIdentity: jest.fn().mockResolvedValue({ subject: 'user' }) },
+  db: {
+    query: jest.fn().mockReturnValue({
+      withIndex: () => ({ unique: jest.fn().mockResolvedValue({ _id: 'u2', role: 'buyer' }) })
+    }),
+  },
+});
+
+describe('admin moderation', () => {
+  it('requires admin role', async () => {
+    const ctx = createUserCtx() as any;
+    await expect(issueWarning._handler(ctx, { userId: 'u1' } as any)).rejects.toThrow('Unauthorized');
+  });
+
+  it('issues warning', async () => {
+    const ctx = createAdminCtx() as any;
+    await issueWarning._handler(ctx, { userId: 'u1' } as any);
+    expect(ctx.db.patch).toHaveBeenCalledWith('u1', { warnings: 1 });
+  });
+
+  it('temporarily bans', async () => {
+    const ctx = createAdminCtx() as any;
+    jest.spyOn(Date, 'now').mockReturnValue(1000);
+    await tempBanUser._handler(ctx, { userId: 'u1', days: 2 } as any);
+    expect(ctx.db.patch).toHaveBeenCalledWith('u1', { bannedUntil: 1000 + 2 * 86400000, role: 'banned' });
+    (Date.now as jest.Mock).mockRestore();
+  });
+
+  it('permanently bans', async () => {
+    const ctx = createAdminCtx() as any;
+    await permBanUser._handler(ctx, { userId: 'u1' } as any);
+    expect(ctx.db.patch).toHaveBeenCalledWith('u1', { bannedUntil: -1, role: 'banned' });
+  });
+});


### PR DESCRIPTION
## Summary
- extend user schema with `warnings` and `bannedUntil`
- implement admin mutations for warnings and bans
- expose moderation controls in admin UI
- test new admin moderation features

## Testing
- `npm install`
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_685d8079c91083278fb24836e3622c44