### PR TITLE
Add forum topic subscriptions with email alerts

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -93,6 +93,15 @@ export default defineSchema({
     .index("by_user", ["userId"])
     .index("by_comment_user", ["commentId", "userId"]),
 
+  topicSubscriptions: defineTable({
+    topicId: v.id("topics"),
+    userId: v.id("users"),
+    createdAt: v.number(),
+  })
+    .index("by_topic", ["topicId"])
+    .index("by_user", ["userId"])
+    .index("by_topic_user", ["topicId", "userId"]),
+
   topicVotes: defineTable({
     topicId: v.id("topics"),
     userId: v.id("users"),

--- a/src/pages/forum.tsx
+++ b/src/pages/forum.tsx
@@ -44,6 +44,8 @@ import {
   Share,
   BarChart2,
   Bookmark,
+  Bell,
+  BellOff,
 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { usePaginatedQuery, useMutation, useQuery } from "convex/react";
@@ -168,6 +170,8 @@ export default function Forum() {
   const incrementViewsMutation = useMutation(api.forum.incrementTopicViews);
   const createCommentMutation = useMutation(api.forum.createComment);
   const toggleCommentVoteMutation = useMutation(api.forum.toggleCommentVote);
+  const subscribeTopicMutation = useMutation(api.forum.subscribeTopic);
+  const unsubscribeTopicMutation = useMutation(api.forum.unsubscribeTopic);
   const initializeCategoriesMutation = useMutation(
     api.forum.initializeCategories,
   );
@@ -207,6 +211,13 @@ export default function Forum() {
 
   const userLikedTopics = useQuery(
     api.forum.hasUserLikedTopic,
+    selectedTopic && currentUser
+      ? { topicId: selectedTopic._id, userId: currentUser._id }
+      : "skip",
+  );
+
+  const isSubscribed = useQuery(
+    api.forum.isUserSubscribed,
     selectedTopic && currentUser
       ? { topicId: selectedTopic._id, userId: currentUser._id }
       : "skip",
@@ -380,6 +391,33 @@ export default function Forum() {
         description: "Gagal mengubah bookmark.",
         variant: "destructive",
       });
+    }
+  };
+
+  const handleSubscribe = async (topicId: Id<"topics">) => {
+    if (!user) {
+      toast({
+        title: "Login diperlukan",
+        description: "Anda harus login untuk berlangganan!",
+        variant: "destructive",
+      });
+      return;
+    }
+    try {
+      await subscribeTopicMutation({ topicId });
+      toast({ title: "Berlangganan" });
+    } catch (err) {
+      console.error("Error subscribe", err);
+    }
+  };
+
+  const handleUnsubscribe = async (topicId: Id<"topics">) => {
+    if (!user) return;
+    try {
+      await unsubscribeTopicMutation({ topicId });
+      toast({ title: "Berhenti langganan" });
+    } catch (err) {
+      console.error("Error unsubscribe", err);
     }
   };
 
@@ -1437,6 +1475,23 @@ export default function Forum() {
                           >
                             <Bookmark className="h-5 w-5" />
                             <span>Koleksi</span>
+                          </button>
+                          <button
+                            onClick={() =>
+                              isSubscribed
+                                ? handleUnsubscribe(selectedTopic._id)
+                                : handleSubscribe(selectedTopic._id)
+                            }
+                            className="flex items-center gap-2 px-4 py-2 rounded-lg hover:bg-gray-50 text-[#718096]"
+                          >
+                            {isSubscribed ? (
+                              <BellOff className="h-5 w-5" />
+                            ) : (
+                              <Bell className="h-5 w-5" />
+                            )}
+                            <span>
+                              {isSubscribed ? "Unsubscribe" : "Subscribe"}
+                            </span>
                           </button>
                           <button
                             onClick={() => {

--- a/src/utils/email.ts
+++ b/src/utils/email.ts
@@ -1,0 +1,23 @@
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+
+export interface EmailOptions {
+  to: string;
+  subject: string;
+  react: React.ReactElement;
+}
+
+export async function sendEmail({ to, subject, react }: EmailOptions) {
+  const html = ReactDOMServer.renderToStaticMarkup(react);
+  const endpoint =
+    (typeof process !== "undefined" && process.env.EMAIL_ENDPOINT) || "";
+  if (endpoint) {
+    await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ to, subject, html }),
+    });
+  } else {
+    console.log("sendEmail", { to, subject });
+  }
+}

--- a/tests/setupTests.ts
+++ b/tests/setupTests.ts
@@ -1,1 +1,4 @@
 import '@testing-library/jest-dom';
+import { TextEncoder, TextDecoder } from 'util';
+(global as any).TextEncoder = TextEncoder;
+(global as any).TextDecoder = TextDecoder;

--- a/tests/unit/topicSubscription.test.ts
+++ b/tests/unit/topicSubscription.test.ts
@@ -1,0 +1,59 @@
+import { subscribeTopic, unsubscribeTopic, sendReplyNotifications } from '../../convex/forum';
+import * as emailUtil from '../../src/utils/email';
+
+describe('topic subscriptions', () => {
+  it('subscribes and unsubscribes user', async () => {
+    const user = { _id: 'u1' };
+    const sub = { _id: 's1', topicId: 't1', userId: 'u1', createdAt: 0 } as any;
+    const ctxSub: any = {
+      auth: { getUserIdentity: jest.fn().mockResolvedValue({ subject: 'tok' }) },
+      db: {
+        query: jest.fn()
+          .mockReturnValueOnce({ withIndex: () => ({ unique: jest.fn().mockResolvedValue(user) }) })
+          .mockReturnValueOnce({ withIndex: () => ({ unique: jest.fn().mockResolvedValue(null) }) }),
+        insert: jest.fn(),
+      },
+    };
+    const res = await subscribeTopic._handler(ctxSub, { topicId: 't1' } as any);
+    expect(res).toBe(true);
+    expect(ctxSub.db.insert).toHaveBeenCalled();
+
+    const ctxUnsub: any = {
+      auth: { getUserIdentity: jest.fn().mockResolvedValue({ subject: 'tok' }) },
+      db: {
+        query: jest.fn()
+          .mockReturnValueOnce({ withIndex: () => ({ unique: jest.fn().mockResolvedValue(user) }) })
+          .mockReturnValueOnce({ withIndex: () => ({ unique: jest.fn().mockResolvedValue(sub) }) }),
+        delete: jest.fn(),
+      },
+    };
+    const res2 = await unsubscribeTopic._handler(ctxUnsub, { topicId: 't1' } as any);
+    expect(res2).toBe(true);
+    expect(ctxUnsub.db.delete).toHaveBeenCalledWith(sub._id);
+  });
+
+  it('sends emails to subscribers', async () => {
+    jest.spyOn(emailUtil, 'sendEmail').mockResolvedValueOnce(undefined as any);
+    const comment = { _id: 'c1', topicId: 't1', content: 'x', authorId: 'u1', authorName: 'A' } as any;
+    const topic = { _id: 't1', title: 'Topic' } as any;
+    const subs = [
+      { _id: 's1', topicId: 't1', userId: 'u2' },
+      { _id: 's2', topicId: 't1', userId: 'u1' },
+    ];
+    const user2 = { _id: 'u2', email: 'b@test.com' } as any;
+    const ctx: any = {
+      db: {
+        get: jest.fn().mockImplementation((id: string) => {
+          if (id === 'c1') return comment;
+          if (id === 't1') return topic;
+          if (id === 'u2') return user2;
+          return null;
+        }),
+        query: jest.fn().mockReturnValue({ withIndex: () => ({ collect: jest.fn().mockResolvedValue(subs) }) }),
+      },
+    };
+    await sendReplyNotifications._handler(ctx, { commentId: 'c1' } as any);
+    expect(emailUtil.sendEmail).toHaveBeenCalledTimes(1);
+    expect((emailUtil.sendEmail as jest.Mock).mock.calls[0][0].to).toBe('b@test.com');
+  });
+});


### PR DESCRIPTION
## Summary
- support subscribing to topics
- email subscribers when new replies are posted
- add subscription controls to the forum page
- add unit tests for subscription features and email dispatch

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d8280cfb48327840d598e7ddb3e55