### PR TITLE
Remove duplicate Forum redirect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,7 +49,6 @@ function App() {
           <Route path="/signup" element={<Signup />} />
           <Route path="/reset-password" element={<ResetPassword />} />
           <Route path="/forum" element={<Forum />} />
-          <Route path="/Forum" element={<Navigate to="/forum" replace />} />
           <Route path="/profile" element={<Profile />} />
           <Route path="/u/:id" element={<Profile />} />
           <Route path="/settings" element={<Settings />} />


### PR DESCRIPTION
## Summary
- clean up app routes by removing unused `/Forum` redirect

## Testing
- `npm test`
- `curl -I http://localhost:5174/forum` while running `npx vite`

------
https://chatgpt.com/codex/tasks/task_e_685e257baff8832795116617a245299a