### PR TITLE
Implement main layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from "react";
 import { Route, Routes, useRoutes, Navigate } from "react-router-dom";
 import routes from "tempo-routes";
+import MainLayout from "./layouts/MainLayout";
 import Dashboard from "./pages/dashboard";
 import Home from "./pages/home";
 import Forum from "./pages/forum";
@@ -43,52 +44,53 @@ function App() {
     <Suspense fallback={<p>Loading...</p>}>
       <>
         <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/dashboard" element={<Dashboard />} />
+          <Route element={<MainLayout />}>
+            <Route path="/" element={<Home />} />
+            <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/forum" element={<Forum />} />
+            <Route path="/profile" element={<Profile />} />
+            <Route path="/u/:id" element={<Profile />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/messages" element={<Messages />} />
+            <Route path="/collections" element={<Collections />} />
+            <Route path="/leaderboard" element={<Leaderboard />} />
+            <Route path="/marketplace" element={<Marketplace />} />
+            <Route
+              path="/marketplace/product/:id"
+              element={<MarketplaceProduct />}
+            />
+            <Route path="/marketplace/sell" element={<MarketplaceSell />} />
+            <Route path="/marketplace/my-shop" element={<MyShop />} />
+            <Route path="/marketplace/sambat" element={<MarketplaceSambat />} />
+            <Route
+              path="/marketplace/sambat/:id"
+              element={<MarketplaceSambatDetail />}
+            />
+            <Route
+              path="/marketplace/sambat/create"
+              element={<MarketplaceSambatCreate />}
+            />
+            <Route
+              path="/marketplace/checkout"
+              element={<MarketplaceCheckout />}
+            />
+            <Route path="/marketplace/order/:orderId" element={<OrderDetail />} />
+            <Route path="/admin" element={<Admin />} />
+            <Route path="/kursus" element={<Kursus />} />
+            <Route path="/kursus/:id" element={<CourseDetail />} />
+            <Route path="/lesson/:id" element={<LessonPage />} />
+            <Route path="/database" element={<Database />} />
+            <Route path="/privacy" element={<Privacy />} />
+            <Route path="/terms" element={<Terms />} />
+            <Route path="/polling" element={<Polling />} />
+            <Route path="/faq" element={<FAQ />} />
+            <Route path="/onboarding" element={<Onboarding />} />
+            <Route path="/order/:orderId/review" element={<OrderReviewPage />} />
+            <Route path="*" element={<NotFound />} />
+          </Route>
           <Route path="/login" element={<Login />} />
           <Route path="/signup" element={<Signup />} />
           <Route path="/reset-password" element={<ResetPassword />} />
-          <Route path="/forum" element={<Forum />} />
-          <Route path="/profile" element={<Profile />} />
-          <Route path="/u/:id" element={<Profile />} />
-          <Route path="/settings" element={<Settings />} />
-          <Route path="/messages" element={<Messages />} />
-          <Route path="/collections" element={<Collections />} />
-          <Route path="/leaderboard" element={<Leaderboard />} />
-          <Route path="/marketplace" element={<Marketplace />} />
-          <Route
-            path="/marketplace/product/:id"
-            element={<MarketplaceProduct />}
-          />
-          <Route path="/marketplace/sell" element={<MarketplaceSell />} />
-          <Route path="/marketplace/my-shop" element={<MyShop />} />
-          <Route path="/marketplace/sambat" element={<MarketplaceSambat />} />
-          <Route
-            path="/marketplace/sambat/:id"
-            element={<MarketplaceSambatDetail />}
-          />
-          <Route
-            path="/marketplace/sambat/create"
-            element={<MarketplaceSambatCreate />}
-          />
-          <Route
-            path="/marketplace/checkout"
-            element={<MarketplaceCheckout />}
-          />
-
-          <Route path="/marketplace/order/:orderId" element={<OrderDetail />} />
-          <Route path="/admin" element={<Admin />} />
-          <Route path="/kursus" element={<Kursus />} />
-          <Route path="/kursus/:id" element={<CourseDetail />} />
-          <Route path="/lesson/:id" element={<LessonPage />} />
-          <Route path="/database" element={<Database />} />
-          <Route path="/privacy" element={<Privacy />} />
-          <Route path="/terms" element={<Terms />} />
-          <Route path="/polling" element={<Polling />} />
-          <Route path="/faq" element={<FAQ />} />
-          <Route path="/onboarding" element={<Onboarding />} />
-          <Route path="/order/:orderId/review" element={<OrderReviewPage />} />
-          <Route path="*" element={<NotFound />} />
         </Routes>
         {import.meta.env.VITE_TEMPO === "true" && useRoutes(routes)}
         <OfflineBanner />

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,0 +1,15 @@
+import { Outlet } from "react-router-dom";
+import { Navbar } from "@/components/navbar";
+import { Footer } from "@/components/footer";
+
+export default function MainLayout() {
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <Navbar />
+      <main className="flex-grow">
+        <Outlet />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import { useQuery, useMutation, useAction } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import {
   Card,
   CardContent,
@@ -124,7 +122,6 @@ function AdminContent() {
 
   return (
     <div className="min-h-screen bg-[#F5F5F7]">
-      <Navbar />
 
       <div className="container mx-auto px-4 py-8">
         <div className="mb-8">
@@ -1434,7 +1431,6 @@ function AdminContent() {
         </Tabs>
       </div>
 
-      <Footer />
     </div>
   );
 }

--- a/src/pages/collections.tsx
+++ b/src/pages/collections.tsx
@@ -1,5 +1,3 @@
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useUser } from "@clerk/clerk-react";
 import { useQuery } from "convex/react";
@@ -28,7 +26,6 @@ function CollectionsContent() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-16 space-y-6">
         <h1 className="text-3xl font-bold text-center mb-8">Koleksi Saya</h1>
         {!bookmarks || bookmarks.length === 0 ? (
@@ -59,7 +56,6 @@ function CollectionsContent() {
           </div>
         )}
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/course-detail.tsx
+++ b/src/pages/course-detail.tsx
@@ -1,8 +1,6 @@
 import { Link, useParams } from "react-router-dom";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 
 export default function CourseDetail() {
@@ -39,7 +37,6 @@ export default function CourseDetail() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-8 space-y-4">
         <h1 className="text-2xl font-bold">{course.title}</h1>
         <p className="text-gray-600">{course.description}</p>
@@ -76,7 +73,6 @@ export default function CourseDetail() {
           </div>
         )}
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -1,8 +1,6 @@
 import { useUser } from "@clerk/clerk-react";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Footer } from "@/components/footer";
-import { Navbar } from "@/components/navbar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -81,7 +79,6 @@ export default function Dashboard() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow">
         <div className="container mx-auto px-4 py-16">
           <div className="relative mb-12">

--- a/src/pages/database.tsx
+++ b/src/pages/database.tsx
@@ -1,5 +1,3 @@
-import { Footer } from "@/components/footer";
-import { Navbar } from "@/components/navbar";
 import {
   Card,
   CardContent,
@@ -119,7 +117,6 @@ export default function Database() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow">
         <div className="container mx-auto px-4 py-12">
           {/* Header */}
@@ -747,7 +744,6 @@ export default function Database() {
           )}
         </div>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/faq.tsx
+++ b/src/pages/faq.tsx
@@ -1,5 +1,3 @@
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 
 export default function FAQ() {
   const faqs = [
@@ -23,7 +21,6 @@ export default function FAQ() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-16 space-y-6">
         <h1 className="text-3xl font-bold text-center mb-8">FAQ</h1>
         {faqs.map((f, idx) => (
@@ -33,7 +30,6 @@ export default function FAQ() {
           </div>
         ))}
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/forum.tsx
+++ b/src/pages/forum.tsx
@@ -1,5 +1,3 @@
-import { Footer } from "@/components/footer";
-import { Navbar } from "@/components/navbar";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -667,7 +665,6 @@ export default function Forum() {
           content="Discuss perfumes and share tips with other enthusiasts"
         />
       </Helmet>
-      <Navbar />
       <main className="flex-grow">
         <div className="container mx-auto px-4 py-12">
           {/* Header */}
@@ -1697,7 +1694,6 @@ export default function Forum() {
           </div>
         </div>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,5 +1,3 @@
-import { Footer } from "@/components/footer";
-import { Navbar } from "@/components/navbar";
 import { Button } from "@/components/ui/button";
 import { useUser } from "@clerk/clerk-react";
 import { Authenticated, Unauthenticated } from "convex/react";
@@ -88,7 +86,6 @@ function App() {
           content="Discover fragrances and join the Sensasi Wangi community"
         />
       </Helmet>
-      <Navbar />
       <main className="flex-grow">
         <div className="container mx-auto px-4 py-24">
           {/* Hero Section */}
@@ -289,7 +286,6 @@ function App() {
           {/* CTA Section */}
         </div>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/kursus.tsx
+++ b/src/pages/kursus.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -213,7 +211,6 @@ export default function Kursus() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
 
       <main className="flex-grow">
         <div className="container mx-auto px-4 py-8">
@@ -449,7 +446,6 @@ export default function Kursus() {
         </div>
       </main>
 
-      <Footer />
     </div>
   );
 }

--- a/src/pages/leaderboard.tsx
+++ b/src/pages/leaderboard.tsx
@@ -1,5 +1,3 @@
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
@@ -22,7 +20,6 @@ export default function Leaderboard() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-16">
         <h1 className="text-3xl font-bold text-center mb-8">Leaderboard</h1>
         {!contributors ? (
@@ -53,7 +50,6 @@ export default function Leaderboard() {
           </div>
         )}
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/lesson.tsx
+++ b/src/pages/lesson.tsx
@@ -2,8 +2,6 @@ import { useParams } from "react-router-dom";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import LessonPlayer from "@/components/lesson-player";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { useState, useEffect } from "react";
@@ -56,7 +54,6 @@ export default function LessonPage() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-8">
         <div className="flex gap-6">
           <div className="flex-1 space-y-6">
@@ -102,7 +99,6 @@ export default function LessonPage() {
           </aside>
         </div>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,6 +1,4 @@
 import { SignIn, useUser } from "@clerk/clerk-react";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Navigate } from "react-router-dom";
 
 export default function Login() {
@@ -12,7 +10,6 @@ export default function Login() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow flex items-center justify-center">
         <SignIn
           path="/login"
@@ -26,7 +23,6 @@ export default function Login() {
           </a>
         </div>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/marketplace-checkout.tsx
+++ b/src/pages/marketplace-checkout.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect } from "react";
 import { useMutation, useQuery, useAction } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -164,7 +162,6 @@ export default function MarketplaceCheckout() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-16">
         <h1 className="text-2xl font-semibold mb-6">Checkout</h1>
         {!orderId ? (
@@ -346,7 +343,6 @@ export default function MarketplaceCheckout() {
           </div>
         )}
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/marketplace-console.tsx
+++ b/src/pages/marketplace-console.tsx
@@ -1,8 +1,6 @@
 import { useUser } from "@clerk/clerk-react";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Footer } from "@/components/footer";
-import { Navbar } from "@/components/navbar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -61,7 +59,6 @@ function MarketplaceConsoleContent() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow">
         <div className="container mx-auto px-4 py-16">
           {/* Header Section */}
@@ -372,7 +369,6 @@ function MarketplaceConsoleContent() {
           </div>
         </div>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/marketplace-product.tsx
+++ b/src/pages/marketplace-product.tsx
@@ -1,8 +1,6 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 import { Star, Share, Instagram, Twitter } from "lucide-react";
 import { Helmet } from "react-helmet";
@@ -67,7 +65,6 @@ export default function MarketplaceProduct() {
           content={product.description || "Product details on Sensasi Wangi"}
         />
       </Helmet>
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-8 space-y-8">
         <div className="flex flex-col md:flex-row gap-8">
           <img
@@ -155,7 +152,6 @@ export default function MarketplaceProduct() {
           </div>
         )}
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/marketplace-sambat-create.tsx
+++ b/src/pages/marketplace-sambat-create.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import { useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -237,7 +235,6 @@ export default function MarketplaceSambatCreate() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
 
       <main className="flex-grow">
         <div className="container mx-auto px-4 py-8">
@@ -793,7 +790,6 @@ export default function MarketplaceSambatCreate() {
         </div>
       </main>
 
-      <Footer />
     </div>
   );
 }

--- a/src/pages/marketplace-sambat-detail.tsx
+++ b/src/pages/marketplace-sambat-detail.tsx
@@ -1,8 +1,6 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Progress } from "@/components/ui/progress";
 import { Helmet } from "react-helmet";
 
@@ -46,7 +44,6 @@ export default function MarketplaceSambatDetail() {
           content={`Join a shared purchase of ${product.title}`}
         />
       </Helmet>
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-8 space-y-8">
         <div className="flex flex-col md:flex-row gap-8">
           <img
@@ -107,7 +104,6 @@ export default function MarketplaceSambatDetail() {
           </div>
         </div>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/marketplace-sambat.tsx
+++ b/src/pages/marketplace-sambat.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect } from "react";
 import { useQuery, useMutation, useAction } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -661,7 +659,6 @@ export default function MarketplaceSambat() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
 
       <main className="flex-grow">
         <div className="container mx-auto px-4 py-8">
@@ -824,7 +821,6 @@ export default function MarketplaceSambat() {
         </div>
       </main>
 
-      <Footer />
     </div>
   );
 }

--- a/src/pages/marketplace-sell.tsx
+++ b/src/pages/marketplace-sell.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -265,7 +263,6 @@ function MarketplaceSellContent() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
 
       <main className="flex-grow">
         <div className="container mx-auto px-4 py-8">
@@ -917,7 +914,6 @@ function MarketplaceSellContent() {
         </div>
       </main>
 
-      <Footer />
     </div>
   );
 }

--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -1,8 +1,6 @@
 import { useState, useEffect } from "react";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import {
@@ -832,7 +830,6 @@ export default function Marketplace() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
 
       <main className="flex-grow">
         <div className="container mx-auto px-4 py-8">
@@ -1155,7 +1152,6 @@ export default function Marketplace() {
         onRemove={removeFromCart}
         onCheckout={() => navigate("/marketplace/checkout")}
       />
-      <Footer />
     </div>
   );
 }

--- a/src/pages/messages.tsx
+++ b/src/pages/messages.tsx
@@ -3,8 +3,6 @@ import { useMutation, useQuery } from "convex/react";
 import { useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import ProtectedRoute from "@/components/wrappers/ProtectedRoute";
@@ -51,7 +49,6 @@ function MessagesContent() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-8 space-y-4">
         <div className="h-96 overflow-y-auto space-y-2 border rounded p-2">
           {messages &&
@@ -77,7 +74,6 @@ function MessagesContent() {
           <Button onClick={handleSend}>Kirim</Button>
         </div>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/my-shop.tsx
+++ b/src/pages/my-shop.tsx
@@ -1,8 +1,6 @@
 import { useUser } from "@clerk/clerk-react";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -42,7 +40,6 @@ function MyShopContent() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-16 space-y-12">
         <section>
           <h1 className="text-3xl font-bold mb-4">Produk Saya</h1>
@@ -110,7 +107,6 @@ function MyShopContent() {
           )}
         </section>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/not-found.tsx
+++ b/src/pages/not-found.tsx
@@ -1,11 +1,8 @@
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Link } from "react-router-dom";
 
 export default function NotFound() {
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow flex flex-col items-center justify-center text-center space-y-4">
         <h1 className="text-3xl font-bold">Page Not Found</h1>
         <p className="text-[#4a5568]">The page you are looking for does not exist.</p>
@@ -13,7 +10,6 @@ export default function NotFound() {
           Back to Home
         </Link>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/onboarding.tsx
+++ b/src/pages/onboarding.tsx
@@ -1,5 +1,3 @@
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { useMutation } from "convex/react";
@@ -43,7 +41,6 @@ export default function Onboarding() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-16">
         {step === 0 && (
           <div className="space-y-4 max-w-md mx-auto">
@@ -116,7 +113,6 @@ export default function Onboarding() {
           </div>
         )}
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/order-detail.tsx
+++ b/src/pages/order-detail.tsx
@@ -1,8 +1,6 @@
 import { useParams } from "react-router-dom";
 import { useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useUser } from "@clerk/clerk-react";
 import ProtectedRoute from "@/components/wrappers/ProtectedRoute";
@@ -47,7 +45,6 @@ function OrderDetailContent() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-16 space-y-6">
         <h1 className="text-2xl font-semibold mb-4">Detail Order</h1>
         <Card className="neumorphic-card border-0">
@@ -110,7 +107,6 @@ function OrderDetailContent() {
           </Card>
         )}
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/order-review.tsx
+++ b/src/pages/order-review.tsx
@@ -1,8 +1,6 @@
 import { useUser } from "@clerk/clerk-react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
@@ -37,7 +35,6 @@ export default function OrderReviewPage() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-16">
         <h1 className="text-2xl font-semibold mb-6">Berikan Ulasan</h1>
         <form onSubmit={onSubmit} className="space-y-4 max-w-lg">
@@ -56,7 +53,6 @@ export default function OrderReviewPage() {
           <Button type="submit">Kirim</Button>
         </form>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/polling.tsx
+++ b/src/pages/polling.tsx
@@ -1,5 +1,3 @@
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { BarChart2 } from "lucide-react";
@@ -28,7 +26,6 @@ export default function Polling() {
 
   return (
     <div className="min-h-screen bg-[#F5F5F7] flex flex-col">
-      <Navbar />
       <main className="flex-grow">
         <div className="container mx-auto px-4 py-8">
           <div className="max-w-xl mx-auto space-y-6">
@@ -74,7 +71,6 @@ export default function Polling() {
           </div>
         </div>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/privacy.tsx
+++ b/src/pages/privacy.tsx
@@ -1,12 +1,9 @@
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Shield, Eye, Lock, Users, Database, Mail } from "lucide-react";
 
 export default function Privacy() {
   return (
     <div className="min-h-screen bg-[#F5F5F7]">
-      <Navbar />
 
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-4xl mx-auto">
@@ -217,7 +214,6 @@ export default function Privacy() {
         </div>
       </div>
 
-      <Footer />
     </div>
   );
 }

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -1,8 +1,6 @@
 import { useUser } from "@clerk/clerk-react";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Footer } from "@/components/footer";
-import { Navbar } from "@/components/navbar";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Link, useParams } from "react-router-dom";
@@ -201,7 +199,6 @@ function ProfileContent() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow">
         <div className="container mx-auto px-4 py-16">
           {/* Header Section */}
@@ -783,7 +780,6 @@ function ProfileContent() {
           </div>
         </div>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/reset-password.tsx
+++ b/src/pages/reset-password.tsx
@@ -1,15 +1,11 @@
 import { SignIn } from "@clerk/clerk-react";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 
 export default function ResetPassword() {
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow flex items-center justify-center">
         <SignIn path="/reset-password" routing="path" />
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/settings.tsx
+++ b/src/pages/settings.tsx
@@ -1,8 +1,6 @@
 import { useUser } from "@clerk/clerk-react";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "../../convex/_generated/api";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -53,7 +51,6 @@ function SettingsContent() {
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow container mx-auto px-4 py-8 space-y-4">
         <h1 className="text-2xl font-bold">Pengaturan Privasi & Sosial</h1>
         <div className="space-y-2">
@@ -123,7 +120,6 @@ function SettingsContent() {
         </div>
         <Button onClick={handleSave}>Simpan</Button>
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,15 +1,11 @@
 import { SignUp } from "@clerk/clerk-react";
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 
 export default function Signup() {
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
-      <Navbar />
       <main className="flex-grow flex items-center justify-center">
         <SignUp path="/signup" routing="path" signInUrl="/login" afterSignUpUrl="/onboarding" />
       </main>
-      <Footer />
     </div>
   );
 }

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -1,5 +1,3 @@
-import { Navbar } from "@/components/navbar";
-import { Footer } from "@/components/footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   FileText,
@@ -13,7 +11,6 @@ import {
 export default function Terms() {
   return (
     <div className="min-h-screen bg-[#F5F5F7]">
-      <Navbar />
 
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-4xl mx-auto">
@@ -316,7 +313,6 @@ export default function Terms() {
         </div>
       </div>
 
-      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add a `MainLayout` component that wraps pages with `<Navbar />` and `<Footer />`
- nest most routes under `MainLayout` in `App.tsx`
- drop direct `Navbar` and `Footer` usage from individual pages

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685e2cb6fd208327837a1d2f2c9af4ea