### PR TITLE
Add seller orders routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import MarketplaceSambat from "./pages/marketplace-sambat";
 import MarketplaceSambatCreate from "./pages/marketplace-sambat-create";
 import MarketplaceSambatDetail from "./pages/marketplace-sambat-detail";
 import MarketplaceProduct from "./pages/marketplace-product";
+import SellerOrders from "./pages/seller-orders";
 import Admin from "./pages/admin";
 import Kursus from "./pages/kursus";
 import CourseDetail from "./pages/course-detail";
@@ -63,6 +64,8 @@ function App() {
             <Route path="/marketplace/my-shop" element={<MyShop />} />
             <Route path="/marketplace/add" element={<MarketplaceSell />} />
             <Route path="/marketplace/lapak" element={<MyShop />} />
+            <Route path="/marketplace/lapak/orders" element={<SellerOrders />} />
+            <Route path="/marketplace/lapak/orders/:id" element={<OrderDetail />} />
             <Route path="/marketplace/sambat" element={<MarketplaceSambat />} />
             <Route
               path="/marketplace/sambat/:id"

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -1077,7 +1077,7 @@ function AdminContent() {
                                   size="sm"
                                   className="neumorphic-button-sm h-8 px-3 text-xs"
                                   onClick={() =>
-                                    navigate(`/marketplace/order/${order._id}`)
+                                    navigate(`/marketplace/lapak/orders/${order._id}`)
                                   }
                                 >
                                   Lihat Detail

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -409,12 +409,14 @@ export default function Dashboard() {
                         ))}
                         {userBuyerOrders.length > 3 && (
                           <div className="text-center pt-4">
-                            <Button
-                              variant="outline"
-                              className="neumorphic-button-sm bg-transparent text-[#718096] border-0 shadow-none"
-                            >
-                              Lihat Semua Pesanan ({userBuyerOrders.length})
-                            </Button>
+                            <Link to="/marketplace/lapak/orders">
+                              <Button
+                                variant="outline"
+                                className="neumorphic-button-sm bg-transparent text-[#718096] border-0 shadow-none"
+                              >
+                                Lihat Semua Pesanan ({userBuyerOrders.length})
+                              </Button>
+                            </Link>
                           </div>
                         )}
                       </div>

--- a/src/pages/marketplace-console.tsx
+++ b/src/pages/marketplace-console.tsx
@@ -293,12 +293,14 @@ function MarketplaceConsoleContent() {
                     ))}
                     {userOrders.length > 3 && (
                       <div className="text-center pt-4">
-                        <Button
-                          variant="outline"
-                          className="neumorphic-button-sm bg-transparent text-[#718096] border-0 shadow-none"
-                        >
-                          Lihat Semua Pesanan ({userOrders.length})
-                        </Button>
+                        <Link to="/marketplace/lapak/orders">
+                          <Button
+                            variant="outline"
+                            className="neumorphic-button-sm bg-transparent text-[#718096] border-0 shadow-none"
+                          >
+                            Lihat Semua Pesanan ({userOrders.length})
+                          </Button>
+                        </Link>
                       </div>
                     )}
                   </div>

--- a/src/pages/my-shop.tsx
+++ b/src/pages/my-shop.tsx
@@ -217,7 +217,7 @@ function MyShopContent() {
                     </div>
                     <Button
                       size="sm"
-                      onClick={() => navigate(`/marketplace/order/${o._id}`)}
+                      onClick={() => navigate(`/marketplace/lapak/orders/${o._id}`)}
                     >
                       Lihat Detail
                     </Button>

--- a/src/pages/seller-orders.tsx
+++ b/src/pages/seller-orders.tsx
@@ -1,0 +1,73 @@
+import { useUser } from "@clerk/clerk-react";
+import { useNavigate, Link } from "react-router-dom";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import RoleProtectedRoute from "@/components/wrappers/RoleProtectedRoute";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+export default function SellerOrders() {
+  return (
+    <RoleProtectedRoute roles={["seller", "admin"]}>
+      <SellerOrdersContent />
+    </RoleProtectedRoute>
+  );
+}
+
+function SellerOrdersContent() {
+  const { user } = useUser();
+  const navigate = useNavigate();
+  const currentUser = useQuery(
+    api.users.getUserByToken,
+    user?.id ? { tokenIdentifier: user.id } : "skip",
+  );
+  const myOrders = useQuery(
+    api.marketplace.getOrdersByUser,
+    currentUser ? { userId: currentUser._id, type: "seller" } : "skip",
+  );
+
+  if (myOrders === undefined) return <div>Loading...</div>;
+
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <main className="flex-grow container mx-auto px-4 py-16 space-y-6">
+        <h1 className="text-3xl font-bold mb-4">Pesanan Saya</h1>
+        {(!myOrders || myOrders.length === 0) ? (
+          <p className="text-center text-[#86868B]">Belum ada pesanan.</p>
+        ) : (
+          <div className="space-y-4">
+            {myOrders.map((o: any) => (
+              <Card key={o._id} className="neumorphic-card border-0">
+                <CardHeader>
+                  <CardTitle className="text-lg font-semibold">
+                    {o.productTitle}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                  <div className="flex items-center gap-2">
+                    <Badge variant="secondary" className="text-xs">
+                      {o.orderStatus}
+                    </Badge>
+                    <span className="text-sm text-[#86868B]">{o.paymentStatus}</span>
+                  </div>
+                  <Button
+                    size="sm"
+                    onClick={() => navigate(`/marketplace/lapak/orders/${o._id}`)}
+                  >
+                    Lihat Detail
+                  </Button>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+        )}
+        <div className="pt-4">
+          <Link to="/marketplace/lapak" className="text-sm text-[#718096]">
+            &larr; Kembali ke Lapak
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add SellerOrders page with order list
- route seller order list & detail paths
- update navigation links to seller orders

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_685fc42a1e948327a0eb072817eed2c4