### PR TITLE
Add order reporting workflow

### DIFF
--- a/convex/marketplace.ts
+++ b/convex/marketplace.ts
@@ -2688,6 +2688,66 @@ export const trackShipment = action({
     },
   });
 
+export const submitOrderReport = mutation({
+  args: { orderId: v.id("orders"), reason: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Anda harus login");
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+      .unique();
+    if (!user) throw new Error("User tidak ditemukan");
+
+    await ctx.db.insert("orderReports", {
+      orderId: args.orderId,
+      reporterId: user._id,
+      reason: args.reason,
+      status: "pending",
+      createdAt: Date.now(),
+    });
+
+    return true;
+  },
+});
+
+export const resolveOrderReport = mutation({
+  args: { reportId: v.id("orderReports"), status: v.optional(v.string()) },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) throw new Error("Unauthenticated");
+    const admin = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+      .unique();
+    if (!admin || admin.role !== "admin") throw new Error("Unauthorized");
+
+    await ctx.db.patch(args.reportId, {
+      status: args.status ?? "resolved",
+    });
+  },
+});
+
+export const getOrderReports = query({
+  handler: async (ctx) => {
+    const [reports, orders, users] = await Promise.all([
+      ctx.db.query("orderReports").collect(),
+      ctx.db.query("orders").collect(),
+      ctx.db.query("users").collect(),
+    ]);
+    const orderMap = new Map(orders.map((o) => [o._id, o.productTitle]));
+    const userMap = new Map(users.map((u) => [u._id, u.name]));
+    return reports.map((r) => ({
+      id: r._id,
+      orderTitle: orderMap.get(r.orderId) ?? "",
+      reporter: userMap.get(r.reporterId) ?? "Unknown",
+      reason: r.reason,
+      status: r.status,
+    }));
+  },
+});
+
 export const expireUnpaidOrders = internalMutation({
   handler: async (ctx) => {
     const now = Date.now();

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -251,6 +251,16 @@ export default defineSchema({
     createdAt: v.number(),
   }).index("by_order", ["orderId"]),
 
+  orderReports: defineTable({
+    orderId: v.id("orders"),
+    reporterId: v.id("users"),
+    reason: v.string(),
+    status: v.string(),
+    createdAt: v.number(),
+  })
+    .index("by_order", ["orderId"])
+    .index("by_reporter", ["reporterId"]),
+
   reviews: defineTable({
     orderId: v.id("orders"),
     productId: v.id("products"),

--- a/src/pages/admin.tsx
+++ b/src/pages/admin.tsx
@@ -88,6 +88,7 @@ function AdminContent() {
   const systemHealth = useQuery(api.admin.getSystemHealth);
   const platformAnalytics = useQuery(api.admin.getPlatformAnalytics);
   const pendingReports = useQuery(api.forum.getTopReports);
+  const orderReports = useQuery(api.marketplace.getOrderReports);
 
   const verifyPayment = useMutation(api.marketplace.verifyOrderPayment);
   const updateStatus = useMutation(api.marketplace.updateOrderStatus);
@@ -99,6 +100,7 @@ function AdminContent() {
   const issueWarning = useMutation(api.admin.issueWarning);
   const tempBanUser = useMutation(api.admin.tempBanUser);
   const permBanUser = useMutation(api.admin.permBanUser);
+  const resolveOrderReport = useMutation(api.marketplace.resolveOrderReport);
   const broadcastMessage = useMutation(api.admin.broadcastSystemMessage);
   const clearCache = useMutation(api.admin.clearSystemCache);
   const backupDatabase = useMutation(api.admin.backupDatabase);
@@ -184,6 +186,13 @@ function AdminContent() {
             >
               <CheckCircle className="w-4 h-4 mr-2" />
               Pesanan
+            </TabsTrigger>
+            <TabsTrigger
+              value="order-reports"
+              className="neumorphic-button-sm data-[state=active]:bg-white data-[state=active]:shadow-inner text-[#1D1D1F]"
+            >
+              <Flag className="w-4 h-4 mr-2" />
+              Order Reports
             </TabsTrigger>
             <TabsTrigger
               value="bri-events"
@@ -411,9 +420,68 @@ function AdminContent() {
                     ))}
                   </TableBody>
                 </Table>
-              </CardContent>
-            </Card>
-          </TabsContent>
+          </CardContent>
+        </Card>
+      </TabsContent>
+
+      <TabsContent value="order-reports" className="space-y-6">
+        <Card className="neumorphic-card border-0">
+          <CardHeader>
+            <CardTitle className="text-[#1D1D1F]">Laporan Pesanan</CardTitle>
+            <CardDescription className="text-[#86868B]">
+              Tinjau dan selesaikan laporan terkait pesanan
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="text-[#1D1D1F]">Pesanan</TableHead>
+                  <TableHead className="text-[#1D1D1F]">Pelapor</TableHead>
+                  <TableHead className="text-[#1D1D1F]">Alasan</TableHead>
+                  <TableHead className="text-[#1D1D1F]">Status</TableHead>
+                  <TableHead className="text-[#1D1D1F]">Aksi</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {!orderReports
+                  ? null
+                  : orderReports.map((rep: any) => (
+                      <TableRow key={rep.id}>
+                        <TableCell className="text-[#1D1D1F]">
+                          {rep.orderTitle}
+                        </TableCell>
+                        <TableCell className="text-[#86868B]">
+                          {rep.reporter}
+                        </TableCell>
+                        <TableCell className="text-[#86868B] max-w-xs truncate">
+                          {rep.reason}
+                        </TableCell>
+                        <TableCell className="text-[#86868B]">
+                          <Badge variant="secondary" className="text-xs">
+                            {rep.status}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>
+                          {rep.status === "pending" && (
+                            <Button
+                              size="sm"
+                              className="neumorphic-button-sm h-8 px-3 text-xs"
+                              onClick={async () => {
+                                await resolveOrderReport({ reportId: rep.id });
+                              }}
+                            >
+                              Resolve
+                            </Button>
+                          )}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </TabsContent>
 
           <TabsContent value="users" className="space-y-6">
             <Card className="neumorphic-card border-0">

--- a/src/pages/order-detail.tsx
+++ b/src/pages/order-detail.tsx
@@ -1,5 +1,5 @@
 import { useParams, Link } from "react-router-dom";
-import { useQuery } from "convex/react";
+import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -29,6 +29,7 @@ function OrderDetailContent() {
     api.marketplace.getOrderTracking,
     order && order.trackingNumber ? { orderId: order._id } : "skip",
   );
+  const submitReport = useMutation(api.marketplace.submitOrderReport);
   if (order === undefined || currentUser === undefined) return <div>Loading...</div>;
   if (order === null) return <div>Order tidak ditemukan</div>;
   if (currentUser && currentUser._id !== order.buyerId && currentUser._id !== order.sellerId) {
@@ -113,6 +114,23 @@ function OrderDetailContent() {
             <Button className="mt-4">Beri Ulasan</Button>
           </Link>
         )}
+        {currentUser &&
+          currentUser._id === order.sellerId &&
+          order.orderStatus === "shipped" &&
+          Date.now() - order.updatedAt > 7 * 24 * 60 * 60 * 1000 && (
+            <Button
+              className="mt-4"
+              onClick={async () => {
+                const reason = window.prompt("Alasan laporan?");
+                if (reason) {
+                  await submitReport({ orderId: order._id, reason });
+                  alert("Laporan dikirim");
+                }
+              }}
+            >
+              Laporkan Masalah
+            </Button>
+          )}
       </main>
     </div>
   );

--- a/tests/unit/orderReports.test.ts
+++ b/tests/unit/orderReports.test.ts
@@ -1,0 +1,44 @@
+import { submitOrderReport, resolveOrderReport } from '../../convex/marketplace';
+
+describe('order reports', () => {
+  it('requires auth to submit', async () => {
+    const ctx = { auth: { getUserIdentity: jest.fn().mockResolvedValue(null) } } as any;
+    await expect(
+      submitOrderReport._handler(ctx, { orderId: 'o1' as any, reason: 'x' })
+    ).rejects.toThrow('Anda harus login');
+  });
+
+  it('creates report', async () => {
+    const ctx: any = {
+      auth: { getUserIdentity: jest.fn().mockResolvedValue({ subject: 'tok' }) },
+      db: {
+        query: jest.fn().mockReturnValue({
+          withIndex: () => ({ unique: jest.fn().mockResolvedValue({ _id: 'u1' }) })
+        }),
+        insert: jest.fn(),
+      },
+    };
+    await submitOrderReport._handler(ctx, { orderId: 'o1' as any, reason: 'spam' });
+    expect(ctx.db.insert).toHaveBeenCalledWith('orderReports', expect.objectContaining({
+      orderId: 'o1',
+      reporterId: 'u1',
+      reason: 'spam',
+      status: 'pending',
+    }));
+  });
+
+  it('resolve requires admin', async () => {
+    const ctx: any = {
+      auth: { getUserIdentity: jest.fn().mockResolvedValue({ subject: 'tok' }) },
+      db: {
+        query: jest.fn().mockReturnValue({
+          withIndex: () => ({ unique: jest.fn().mockResolvedValue({ _id: 'u2', role: 'buyer' }) })
+        }),
+        patch: jest.fn(),
+      },
+    };
+    await expect(
+      resolveOrderReport._handler(ctx, { reportId: 'r1' as any, status: undefined })
+    ).rejects.toThrow('Unauthorized');
+  });
+});


### PR DESCRIPTION
## Summary
- add `orderReports` table to schema
- support submitting and resolving order reports in marketplace backend
- expose order reports management in admin panel
- allow sellers to report unconfirmed orders from order detail page
- unit tests for order report logic

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860bd8a19a88327b173cdb0cda6eabf