### PR TITLE
Add daily shipment refresh cron

### DIFF
--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -9,6 +9,12 @@ crons.daily(
   internal.marketplace.expireUnpaidOrders,
 );
 
+crons.daily(
+  "refresh-all-shipments",
+  { hourUTC: 0, minuteUTC: 10 },
+  internal.marketplace.refreshAllShipments,
+);
+
 crons.weekly(
   "update-weekly-leaderboard",
   { dayOfWeek: "monday", hourUTC: 0, minuteUTC: 5 },


### PR DESCRIPTION
## Summary
- create an internal action to refresh shipment tracking on all shipped orders
- expose a helper query for shipped orders
- schedule the job daily via cron

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c2262f788327aaa821aed44387f9