### PR TITLE
Add order cancellation feature

### DIFF
--- a/convex/marketplace.ts
+++ b/convex/marketplace.ts
@@ -820,6 +820,51 @@ export const updateOrderStatus = mutation({
   },
 });
 
+export const cancelOrder = mutation({
+  args: { orderId: v.id("orders") },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Anda harus login untuk membatalkan order");
+    }
+
+    const user = await ctx.db
+      .query("users")
+      .withIndex("by_token", (q) => q.eq("tokenIdentifier", identity.subject))
+      .unique();
+
+    if (!user) {
+      throw new Error("User tidak ditemukan");
+    }
+
+    const order = await ctx.db.get(args.orderId);
+    if (!order) {
+      throw new Error("Order tidak ditemukan");
+    }
+
+    if (order.buyerId !== user._id) {
+      throw new Error("Anda bukan pembeli order ini");
+    }
+
+    await ctx.db.patch(args.orderId, {
+      orderStatus: "cancelled",
+      paymentStatus: "failed",
+      updatedAt: Date.now(),
+    });
+
+    const product = await ctx.db.get(order.productId);
+    if (product) {
+      await ctx.db.patch(order.productId, {
+        status: "active",
+        stock: (product.stock || 0) + 1,
+        updatedAt: Date.now(),
+      });
+    }
+
+    return true;
+  },
+});
+
 export const releaseSellerPayment = mutation({
   args: { orderId: v.id("orders") },
   handler: async (ctx, args) => {

--- a/src/pages/marketplace-checkout.tsx
+++ b/src/pages/marketplace-checkout.tsx
@@ -66,6 +66,10 @@ export default function MarketplaceCheckout() {
   const [file, setFile] = useState<File | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [shippingCost, setShippingCost] = useState(0);
+  const order = useQuery(
+    api.marketplace.getOrderById,
+    orderId ? { orderId: orderId as any } : "skip",
+  );
 
   useEffect(() => {
     if (productId) {
@@ -95,6 +99,12 @@ export default function MarketplaceCheckout() {
     };
     loadCost();
   }, [shippingMethod, shippingAddress.city, cart]);
+
+  useEffect(() => {
+    if (order && order.orderStatus === "cancelled") {
+      navigate("/dashboard");
+    }
+  }, [order, navigate]);
 
   const formatPrice = (price: number) =>
     new Intl.NumberFormat("id-ID", {

--- a/src/pages/order-detail.tsx
+++ b/src/pages/order-detail.tsx
@@ -1,4 +1,4 @@
-import { useParams, Link } from "react-router-dom";
+import { useParams, Link, useNavigate } from "react-router-dom";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -25,11 +25,13 @@ function OrderDetailContent() {
     api.marketplace.getOrderById,
     orderId ? { orderId: orderId as any } : "skip",
   );
+  const cancelOrder = useMutation(api.marketplace.cancelOrder);
   const tracking = useQuery(
     api.marketplace.getOrderTracking,
     order && order.trackingNumber ? { orderId: order._id } : "skip",
   );
   const submitReport = useMutation(api.marketplace.submitOrderReport);
+  const navigate = useNavigate();
   if (order === undefined || currentUser === undefined) return <div>Loading...</div>;
   if (order === null) return <div>Order tidak ditemukan</div>;
   if (currentUser && currentUser._id !== order.buyerId && currentUser._id !== order.sellerId) {
@@ -114,6 +116,21 @@ function OrderDetailContent() {
             <Button className="mt-4">Beri Ulasan</Button>
           </Link>
         )}
+        {currentUser &&
+          currentUser._id === order.buyerId &&
+          order.paymentStatus === "pending" && (
+            <Button
+              className="mt-4"
+              onClick={async () => {
+                if (confirm("Batalkan order ini?")) {
+                  await cancelOrder({ orderId: order._id });
+                  navigate("/dashboard");
+                }
+              }}
+            >
+              Batalkan Order
+            </Button>
+          )}
         {currentUser &&
           currentUser._id === order.sellerId &&
           order.orderStatus === "shipped" &&


### PR DESCRIPTION
## Summary
- implement `cancelOrder` mutation that validates buyer and restores stock
- show **Batalkan Order** action when payment is pending
- redirect checkout page when order cancelled

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860c2352e3883278dc5ad71196393b1