### PR TITLE
Add shipping address profile support

### DIFF
--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -362,6 +362,16 @@ export default defineSchema({
     twitter: v.optional(v.string()),
     website: v.optional(v.string()),
     interests: v.optional(v.array(v.string())),
+    shippingAddress: v.optional(
+      v.object({
+        name: v.string(),
+        phone: v.string(),
+        address: v.string(),
+        city: v.string(),
+        postalCode: v.string(),
+        province: v.string(),
+      }),
+    ),
     avatar: v.optional(v.string()),
     isVerified: v.boolean(),
     rating: v.number(),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -134,6 +134,7 @@ export const createOrUpdateUser = mutation({
             instagram: undefined,
             twitter: undefined,
             website: undefined,
+            shippingAddress: undefined,
             avatar: null,
             isVerified: false,
             rating: 0,
@@ -192,6 +193,7 @@ export const createOrUpdateUser = mutation({
       instagram: undefined,
       twitter: undefined,
       website: undefined,
+      shippingAddress: undefined,
       avatar: null,
       isVerified: false,
       rating: 0,
@@ -228,6 +230,16 @@ export const updateUserProfile = mutation({
     twitter: v.optional(v.string()),
     website: v.optional(v.string()),
     avatar: v.optional(v.string()),
+    shippingAddress: v.optional(
+      v.object({
+        name: v.string(),
+        phone: v.string(),
+        address: v.string(),
+        city: v.string(),
+        postalCode: v.string(),
+        province: v.string(),
+      }),
+    ),
   },
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
@@ -256,6 +268,7 @@ export const updateUserProfile = mutation({
     twitter: args.twitter,
     website: args.website,
     avatar: args.avatar,
+    shippingAddress: args.shippingAddress,
     lastActive: now,
   } as any;
     if (existing) {
@@ -266,6 +279,7 @@ export const updateUserProfile = mutation({
       userId: user._id,
       ...profilePatch,
       avatar: args.avatar ?? null,
+      shippingAddress: args.shippingAddress,
       isVerified: false,
       rating: 0,
       totalReviews: 0,


### PR DESCRIPTION
## Summary
- preload shipping data in marketplace checkout from user profile
- allow users to save checkout address to their profile
- extend user profile schema and mutation to store shipping addresses

## Testing
- `npm run lint` *(fails: ESLint couldn't find a config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c262540c8327beda4f669ff87742