### PR TITLE
Add cart page and update checkout flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import ResetPassword from "./pages/reset-password";
 import OrderReviewPage from "./pages/order-review";
 import OrderDetail from "./pages/order-detail";
 import MarketplaceCheckout from "./pages/marketplace-checkout";
+import CartPage from "./pages/cart";
 import Messages from "./pages/messages";
 import Leaderboard from "./pages/leaderboard";
 
@@ -75,6 +76,7 @@ function App() {
               path="/marketplace/sambat/create"
               element={<MarketplaceSambatCreate />}
             />
+            <Route path="/marketplace/cart" element={<CartPage />} />
             <Route
               path="/marketplace/checkout"
               element={<MarketplaceCheckout />}

--- a/src/pages/cart.tsx
+++ b/src/pages/cart.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { X, Plus, Minus } from "lucide-react";
+
+export type CartItem = {
+  id: string;
+  title: string;
+  price: number;
+  quantity?: number;
+};
+
+export default function CartPage() {
+  const navigate = useNavigate();
+  const [cart, setCart] = useState<CartItem[]>([]);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("marketplaceCart");
+    if (stored) {
+      const items = JSON.parse(stored).map((i: any) => ({
+        ...i,
+        quantity: i.quantity || 1,
+      }));
+      setCart(items);
+    }
+  }, []);
+
+  const updateStorage = (items: CartItem[]) => {
+    localStorage.setItem("marketplaceCart", JSON.stringify(items));
+  };
+
+  const changeQty = (id: string, qty: number) => {
+    setCart((prev) => {
+      const updated = prev.map((item) =>
+        item.id === id ? { ...item, quantity: qty } : item,
+      );
+      updateStorage(updated);
+      return updated;
+    });
+  };
+
+  const increment = (id: string) => {
+    const item = cart.find((i) => i.id === id);
+    if (!item) return;
+    changeQty(id, (item.quantity || 1) + 1);
+  };
+
+  const decrement = (id: string) => {
+    const item = cart.find((i) => i.id === id);
+    if (!item) return;
+    const newQty = Math.max(1, (item.quantity || 1) - 1);
+    changeQty(id, newQty);
+  };
+
+  const removeItem = (id: string) => {
+    setCart((prev) => {
+      const updated = prev.filter((i) => i.id !== id);
+      updateStorage(updated);
+      return updated;
+    });
+  };
+
+  const formatPrice = (price: number) =>
+    new Intl.NumberFormat("id-ID", {
+      style: "currency",
+      currency: "IDR",
+      minimumFractionDigits: 0,
+    }).format(price);
+
+  const subtotal = cart.reduce(
+    (s, i) => s + i.price * (i.quantity || 1),
+    0,
+  );
+
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <main className="flex-grow container mx-auto px-4 py-8 max-w-lg space-y-4">
+        <h1 className="text-2xl font-semibold">Keranjang</h1>
+        {cart.length === 0 ? (
+          <p className="text-center text-sm text-[#718096]">Keranjang kosong</p>
+        ) : (
+          <div className="space-y-4">
+            {cart.map((item) => (
+              <div
+                key={item.id}
+                className="flex items-center justify-between"
+              >
+                <div className="flex-1 mr-2">
+                  <p className="line-clamp-1 font-medium">{item.title}</p>
+                  <p className="text-sm">{formatPrice(item.price)}</p>
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    size="icon"
+                    variant="outline"
+                    onClick={() => decrement(item.id)}
+                  >
+                    <Minus className="h-4 w-4" />
+                  </Button>
+                  <Input
+                    className="w-12 h-8 text-center"
+                    type="number"
+                    min={1}
+                    value={item.quantity || 1}
+                    onChange={(e) =>
+                      changeQty(item.id, Math.max(1, parseInt(e.target.value) || 1))
+                    }
+                  />
+                  <Button
+                    size="icon"
+                    variant="outline"
+                    onClick={() => increment(item.id)}
+                  >
+                    <Plus className="h-4 w-4" />
+                  </Button>
+                </div>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  onClick={() => removeItem(item.id)}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+            ))}
+            <div className="flex justify-between font-semibold border-t pt-2">
+              <span>Total</span>
+              <span>{formatPrice(subtotal)}</span>
+            </div>
+            <Button onClick={() => navigate("/marketplace/checkout")}>Checkout</Button>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/pages/marketplace-checkout.tsx
+++ b/src/pages/marketplace-checkout.tsx
@@ -30,7 +30,12 @@ const PAYMENT_METHODS = [
   { value: "qris", label: "QRIS" },
 ];
 
-type CartItem = { id: string; title: string; price: number };
+type CartItem = {
+  id: string;
+  title: string;
+  price: number;
+  quantity?: number;
+};
 
 export default function MarketplaceCheckout() {
   const { user } = useUser();
@@ -70,11 +75,19 @@ export default function MarketplaceCheckout() {
   useEffect(() => {
     if (productId) {
       if (product) {
-        setCart([{ id: product._id, title: product.title, price: product.price }]);
+        setCart([
+          { id: product._id, title: product.title, price: product.price, quantity: 1 },
+        ]);
       }
     } else {
       const stored = localStorage.getItem("marketplaceCart");
-      if (stored) setCart(JSON.parse(stored));
+      if (stored) {
+        const items = JSON.parse(stored).map((i: any) => ({
+          ...i,
+          quantity: i.quantity || 1,
+        }));
+        setCart(items);
+      }
     }
   }, [productId, product]);
 
@@ -82,11 +95,12 @@ export default function MarketplaceCheckout() {
     const loadCost = async () => {
       if (!shippingMethod || !shippingAddress.city || cart.length === 0) return;
       try {
+        const qty = cart.reduce((s, i) => s + (i.quantity || 1), 0);
         const cost = await calculateCost({
           origin: shippingAddress.city,
           destination: shippingAddress.city,
           courier: shippingMethod,
-          weight: cart.length * 1000,
+          weight: qty * 1000,
         });
         setShippingCost(cost);
       } catch (err) {
@@ -103,7 +117,10 @@ export default function MarketplaceCheckout() {
       minimumFractionDigits: 0,
     }).format(price);
 
-  const subtotal = cart.reduce((s, i) => s + i.price, 0);
+  const subtotal = cart.reduce(
+    (s, i) => s + i.price * (i.quantity || 1),
+    0,
+  );
   const totalAmount = subtotal + shippingCost;
 
   if (productId && product === undefined) return <div>Loading...</div>;
@@ -169,8 +186,12 @@ export default function MarketplaceCheckout() {
             <div className="space-y-2">
               {cart.map((item) => (
                 <div key={item.id} className="flex justify-between text-sm">
-                  <span>{item.title}</span>
-                  <span>{formatPrice(item.price)}</span>
+                  <span>
+                    {item.title} x{item.quantity || 1}
+                  </span>
+                  <span>
+                    {formatPrice(item.price * (item.quantity || 1))}
+                  </span>
                 </div>
               ))}
               <div className="flex justify-between text-sm">

--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -76,7 +76,7 @@ const SORT_OPTIONS = [
   { value: "liked", label: "Paling Disukai" },
 ];
 
-type CartItem = { id: string; title: string; price: number };
+type CartItem = { id: string; title: string; price: number; quantity?: number };
 
 function ProductCard({
   product,
@@ -715,7 +715,10 @@ function CartDialog({
       currency: "IDR",
       minimumFractionDigits: 0,
     }).format(price);
-  const total = cart.reduce((sum, i) => sum + i.price, 0);
+  const total = cart.reduce(
+    (sum, i) => sum + i.price * (i.quantity || 1),
+    0,
+  );
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
@@ -736,8 +739,12 @@ function CartDialog({
               key={item.id}
               className="flex items-center justify-between"
             >
-              <span className="flex-1 mr-2 line-clamp-1">{item.title}</span>
-              <span className="text-sm">{formatPrice(item.price)}</span>
+              <span className="flex-1 mr-2 line-clamp-1">
+                {item.title} x{item.quantity || 1}
+              </span>
+              <span className="text-sm">
+                {formatPrice(item.price * (item.quantity || 1))}
+              </span>
               <Button
                 size="icon"
                 variant="ghost"
@@ -785,14 +792,27 @@ export default function Marketplace() {
   useEffect(() => {
     const stored = localStorage.getItem("marketplaceCart");
     if (stored) {
-      setCart(JSON.parse(stored));
+      const items = JSON.parse(stored).map((i: any) => ({
+        ...i,
+        quantity: i.quantity || 1,
+      }));
+      setCart(items);
     }
   }, []);
 
   const addToCart = (item: CartItem) => {
     setCart((prev) => {
-      if (prev.some((p) => p.id === item.id)) return prev;
-      const updated = [...prev, item];
+      const existing = prev.find((p) => p.id === item.id);
+      let updated: CartItem[];
+      if (existing) {
+        updated = prev.map((p) =>
+          p.id === item.id
+            ? { ...p, quantity: (p.quantity || 1) + 1 }
+            : p,
+        );
+      } else {
+        updated = [...prev, { ...item, quantity: 1 }];
+      }
       localStorage.setItem("marketplaceCart", JSON.stringify(updated));
       return updated;
     });
@@ -1150,7 +1170,7 @@ export default function Marketplace() {
       <CartDialog
         cart={cart}
         onRemove={removeFromCart}
-        onCheckout={() => navigate("/marketplace/checkout")}
+        onCheckout={() => navigate("/marketplace/cart")}
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- create `cart.tsx` page to manage items from `localStorage`
- support quantities in cart logic and display
- register `/marketplace/cart` route and update checkout links
- adjust marketplace checkout and dialog totals to handle quantity

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6860c26c1fa88327a5692802fa41a6e3