### PR TITLE
Add CSV export for seller orders

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,6 +53,7 @@
         "framer-motion": "^11.18.0",
         "i18next": "^25.2.1",
         "lucide-react": "^0.394.0",
+        "papaparse": "^5.5.3",
         "react": "^18.2.0",
         "react-chartjs-2": "^5.3.0",
         "react-day-picker": "^8.10.1",
@@ -11494,6 +11495,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.0.tgz",
       "integrity": "sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw=="
+    },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
     },
     "node_modules/parse-code-context": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "tailwindcss-animate": "^1.0.7",
     "vaul": "^0.9.1",
     "web-push": "^3.6.7",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "papaparse": "^5.5.3"
   },
   "devDependencies": {
     "@swc/core": "1.3.96",

--- a/src/pages/seller-orders.tsx
+++ b/src/pages/seller-orders.tsx
@@ -6,6 +6,7 @@ import RoleProtectedRoute from "@/components/wrappers/RoleProtectedRoute";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import Papa from "papaparse";
 
 export default function SellerOrders() {
   return (
@@ -27,12 +28,37 @@ function SellerOrdersContent() {
     currentUser ? { userId: currentUser._id, type: "seller" } : "skip",
   );
 
+  const handleExport = () => {
+    if (!myOrders || myOrders.length === 0) return;
+    const data = myOrders.map((o: any) => ({
+      orderDate: new Date(o.createdAt).toLocaleDateString("id-ID"),
+      buyerName: o.buyerName,
+      productTitle: o.productTitle,
+      status: o.orderStatus,
+      totalAmount: o.totalAmount,
+    }));
+    const csv = Papa.unparse(data);
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.setAttribute("download", "orders.csv");
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
+
   if (myOrders === undefined) return <div>Loading...</div>;
 
   return (
     <div className="min-h-screen flex flex-col neumorphic-bg">
       <main className="flex-grow container mx-auto px-4 py-16 space-y-6">
-        <h1 className="text-3xl font-bold mb-4">Pesanan Saya</h1>
+        <div className="flex items-center justify-between mb-4">
+          <h1 className="text-3xl font-bold">Pesanan Saya</h1>
+          <Button size="sm" onClick={handleExport}>
+            Export CSV
+          </Button>
+        </div>
         {(!myOrders || myOrders.length === 0) ? (
           <p className="text-center text-[#86868B]">Belum ada pesanan.</p>
         ) : (


### PR DESCRIPTION
## Summary
- add PapaParse dependency
- implement CSV export for seller orders

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c27668548327abb9f347b19a9d9f