### PR TITLE
Add wishlist feature

### DIFF
--- a/api-server.js
+++ b/api-server.js
@@ -63,6 +63,17 @@ app.get('/api/fragrances', async (req, res) => {
   }
 });
 
+app.get('/api/wishlists/:userId', async (req, res) => {
+  try {
+    const result = await convex.query(api.marketplace.getWishlistByUser, {
+      userId: req.params.userId,
+    });
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
 app.get('/api/stats', async (req, res) => {
   try {
     const stats = await convex.query(api.marketplace.getDatabaseStats, {});

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -558,6 +558,15 @@ export default defineSchema({
     .index("by_item", ["itemId"])
     .index("by_user_item", ["userId", "itemId"]),
 
+  wishlists: defineTable({
+    userId: v.id("users"),
+    productId: v.id("products"),
+    createdAt: v.number(),
+  })
+    .index("by_user", ["userId"])
+    .index("by_product", ["productId"])
+    .index("by_user_product", ["userId", "productId"]),
+
   savedSearches: defineTable({
     userId: v.id("users"),
     name: v.string(),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import MarketplaceSambat from "./pages/marketplace-sambat";
 import MarketplaceSambatCreate from "./pages/marketplace-sambat-create";
 import MarketplaceSambatDetail from "./pages/marketplace-sambat-detail";
 import MarketplaceProduct from "./pages/marketplace-product";
+import MarketplaceWishlist from "./pages/marketplace-wishlist";
 import SellerOrders from "./pages/seller-orders";
 import Admin from "./pages/admin";
 import Kursus from "./pages/kursus";
@@ -62,6 +63,7 @@ function App() {
               path="/marketplace/product/:id"
               element={<MarketplaceProduct />}
             />
+            <Route path="/marketplace/wishlist" element={<MarketplaceWishlist />} />
             <Route path="/marketplace/sell" element={<MarketplaceSell />} />
             <Route path="/marketplace/my-shop" element={<MyShop />} />
             <Route path="/marketplace/add" element={<MarketplaceSell />} />

--- a/src/constants/menu.tsx
+++ b/src/constants/menu.tsx
@@ -22,6 +22,17 @@ const MarketplaceIcon = (props: SVGProps<SVGSVGElement>) => (
   </svg>
 );
 
+const WishlistIcon = (props: SVGProps<SVGSVGElement>) => (
+  <svg {...props} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={1.5}
+      d="M3.172 5.172a4 4 0 015.656 0L12 8.343l3.172-3.171a4 4 0 115.656 5.656L12 21.657l-8.828-8.829a4 4 0 010-5.656z"
+    />
+  </svg>
+);
+
 const KursusIcon = (props: SVGProps<SVGSVGElement>) => (
   <svg {...props} fill="none" viewBox="0 0 24 24" stroke="currentColor">
     <path
@@ -58,6 +69,7 @@ const LeaderboardIcon = (props: SVGProps<SVGSVGElement>) => (
 export const NAV_ITEMS = [
   { label: "Forum", to: "/forum", icon: ForumIcon },
   { label: "Marketplace", to: "/marketplace", icon: MarketplaceIcon },
+  { label: "Wishlist", to: "/marketplace/wishlist", icon: WishlistIcon },
   { label: "Kursus", to: "/kursus", icon: KursusIcon },
   { label: "Database", to: "/database", icon: DatabaseIcon },
   { label: "Leaderboard", to: "/leaderboard", icon: LeaderboardIcon },

--- a/src/pages/marketplace-product.tsx
+++ b/src/pages/marketplace-product.tsx
@@ -1,12 +1,15 @@
 import { useParams } from "react-router-dom";
-import { useQuery } from "convex/react";
+import { useQuery, useMutation } from "convex/react";
 import { api } from "../../convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { Star, Share, Instagram, Twitter } from "lucide-react";
+import { useUser } from "@clerk/clerk-react";
 import { Helmet } from "react-helmet";
 
 export default function MarketplaceProduct() {
   const { id } = useParams();
+  const { user } = useUser();
+  const addWishlist = useMutation(api.marketplace.addToWishlist);
   const product = useQuery(
     api.marketplace.getProductById,
     id ? { productId: id as any } : "skip",
@@ -100,6 +103,13 @@ export default function MarketplaceProduct() {
               </p>
             )}
             <Button className="mt-4">Beli</Button>
+            <Button
+              variant="outline"
+              className="mt-4 ml-2"
+              onClick={() => user && addWishlist({ productId: product._id })}
+            >
+              Tambah ke Wishlist
+            </Button>
             <div className="flex gap-2 mt-4">
               <Button
                 variant="secondary"

--- a/src/pages/marketplace-wishlist.tsx
+++ b/src/pages/marketplace-wishlist.tsx
@@ -1,0 +1,58 @@
+import { useUser } from "@clerk/clerk-react";
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Link } from "react-router-dom";
+
+export default function MarketplaceWishlist() {
+  const { user } = useUser();
+  const wishlist = useQuery(
+    api.marketplace.getWishlistByUser,
+    user ? { userId: user.id as any } : "skip",
+  );
+
+  const formatPrice = (price: number) =>
+    new Intl.NumberFormat("id-ID", {
+      style: "currency",
+      currency: "IDR",
+      minimumFractionDigits: 0,
+    }).format(price);
+
+  if (!user) return <div>Login terlebih dahulu</div>;
+  if (wishlist === undefined) return <div>Loading...</div>;
+
+  return (
+    <div className="min-h-screen flex flex-col neumorphic-bg">
+      <main className="flex-grow container mx-auto px-4 py-8">
+        <h1 className="text-2xl font-semibold mb-6">Wishlist</h1>
+        {wishlist.length === 0 ? (
+          <p>Wishlist kosong</p>
+        ) : (
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+            {wishlist.map((p: any) => (
+              <Card key={p._id} className="neumorphic-card p-4">
+                <img
+                  src={
+                    p.images[0] ||
+                    "https://images.unsplash.com/photo-1541643600914-78b084683601?w=400&q=80"
+                  }
+                  alt={p.title}
+                  className="w-full h-40 object-cover rounded-xl"
+                />
+                <h3 className="mt-2 font-semibold line-clamp-1">{p.title}</h3>
+                <p className="text-sm">{p.brand}</p>
+                <p className="font-bold">{formatPrice(p.price)}</p>
+                <Link to={`/marketplace/product/${p._id}`}>
+                  <Button size="sm" className="mt-2">
+                    Lihat
+                  </Button>
+                </Link>
+              </Card>
+            ))}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/pages/marketplace.tsx
+++ b/src/pages/marketplace.tsx
@@ -961,6 +961,13 @@ export default function Marketplace() {
                 <Plus className="h-4 w-4 mr-2" />
                 Jual Produk
               </Button>
+              <Button
+                onClick={() => navigate("/marketplace/wishlist")}
+                className="neumorphic-button text-[#2d3748] bg-transparent border-0 shadow-none"
+              >
+                <Heart className="h-4 w-4 mr-2" />
+                Wishlist
+              </Button>
             </div>
 
             {showFilters && (


### PR DESCRIPTION
## Summary
- add `wishlists` table to schema
- support wishlist operations in marketplace functions
- expose wishlist query via REST
- link wishlist in navigation and marketplace page
- show button to add product to wishlist
- create wishlist page and route

## Testing
- `npx jest` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68628bb86f2c83279a9886c1a0c41447