### PR TITLE
Add follower/following lists on profile

### DIFF
--- a/src/components/followers-list.tsx
+++ b/src/components/followers-list.tsx
@@ -1,0 +1,46 @@
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import FollowButton from "@/components/follow-button";
+import { Id } from "../../convex/_generated/dataModel";
+
+function getInitials(name: string | null | undefined) {
+  if (!name) return "U";
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+export default function FollowersList({ userId }: { userId: Id<"users"> }) {
+  const followers = useQuery(api.follows.getFollowers, { userId });
+
+  if (followers === undefined) {
+    return <div className="p-4 text-center">Memuat...</div>;
+  }
+
+  if (!followers.length) {
+    return (
+      <div className="p-4 text-center text-[#86868B]">Belum ada pengikut.</div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {followers.map((u: any) => (
+        <div key={u._id} className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Avatar className="w-8 h-8">
+              <AvatarImage src={u.image} alt={u.name || "User"} />
+              <AvatarFallback>{getInitials(u.name)}</AvatarFallback>
+            </Avatar>
+            <span className="text-sm font-medium text-[#1D1D1F]">{u.name}</span>
+          </div>
+          <FollowButton userId={u._id as any} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/following-list.tsx
+++ b/src/components/following-list.tsx
@@ -1,0 +1,46 @@
+import { useQuery } from "convex/react";
+import { api } from "../../convex/_generated/api";
+import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import FollowButton from "@/components/follow-button";
+import { Id } from "../../convex/_generated/dataModel";
+
+function getInitials(name: string | null | undefined) {
+  if (!name) return "U";
+  return name
+    .split(" ")
+    .map((n) => n[0])
+    .join("")
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+export default function FollowingList({ userId }: { userId: Id<"users"> }) {
+  const following = useQuery(api.follows.getFollowing, { userId });
+
+  if (following === undefined) {
+    return <div className="p-4 text-center">Memuat...</div>;
+  }
+
+  if (!following.length) {
+    return (
+      <div className="p-4 text-center text-[#86868B]">Belum mengikuti siapa pun.</div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {following.map((u: any) => (
+        <div key={u._id} className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Avatar className="w-8 h-8">
+              <AvatarImage src={u.image} alt={u.name || "User"} />
+              <AvatarFallback>{getInitials(u.name)}</AvatarFallback>
+            </Avatar>
+            <span className="text-sm font-medium text-[#1D1D1F]">{u.name}</span>
+          </div>
+          <FollowButton userId={u._id as any} />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/profile.tsx
+++ b/src/pages/profile.tsx
@@ -5,6 +5,9 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Link, useParams } from "react-router-dom";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import FollowersList from "@/components/followers-list";
+import FollowingList from "@/components/following-list";
 import { uploadImage } from "@/utils/cloudinary";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
@@ -106,6 +109,8 @@ function ProfileContent() {
   const [bio, setBio] = useState("");
   const fileInputRef = useRef<HTMLInputElement>(null);
 
+  const [showFollowers, setShowFollowers] = useState(false);
+  const [showFollowing, setShowFollowing] = useState(false);
   useEffect(() => {
     setFullName(user?.fullName || "");
     setUsername(user?.username || "");
@@ -395,19 +400,42 @@ function ProfileContent() {
                       <Users className="h-4 w-4 text-[#667eea]" />
                       <span className="text-sm text-[#86868B]">Pengikut</span>
                     </div>
-                    <span className="text-sm font-semibold text-[#1D1D1F]">
-                      {followers?.length || 0}
-                    </span>
+                    <Dialog open={showFollowers} onOpenChange={setShowFollowers}>
+                      <DialogTrigger asChild>
+                        <span className="text-sm font-semibold text-[#1D1D1F] cursor-pointer">
+                          {followers?.length || 0}
+                        </span>
+                      </DialogTrigger>
+                      <DialogContent className="neumorphic-card border-0 max-w-md">
+                        <DialogHeader>
+                          <DialogTitle className="text-[#2d3748]">Pengikut</DialogTitle>
+                        </DialogHeader>
+                        {profileData && (
+                          <FollowersList userId={profileData.user._id as any} />
+                        )}
+                      </DialogContent>
+                    </Dialog>
                   </div>
                   <div className="flex justify-between items-center">
-                    <div className="flex items-center gap-2">
-                      <Users className="h-4 w-4 text-[#667eea]" />
-                      <span className="text-sm text-[#86868B]">Mengikuti</span>
-                    </div>
-                    <span className="text-sm font-semibold text-[#1D1D1F]">
-                      {following?.length || 0}
-                    </span>
-                  </div>
+                      <div className="flex items-center gap-2">
+                        <Users className="h-4 w-4 text-[#667eea]" />
+                        <span className="text-sm text-[#86868B]">Mengikuti</span>
+                      </div>
+                      <Dialog open={showFollowing} onOpenChange={setShowFollowing}>
+                        <DialogTrigger asChild>
+                          <span className="text-sm font-semibold text-[#1D1D1F] cursor-pointer">
+                            {following?.length || 0}
+                          </span>
+                        </DialogTrigger>
+                        <DialogContent className="neumorphic-card border-0 max-w-md">
+                          <DialogHeader>
+                            <DialogTitle className="text-[#2d3748]">Mengikuti</DialogTitle>
+                          </DialogHeader>
+                          {profileData && (
+                            <FollowingList userId={profileData.user._id as any} />
+                          )}
+                        </DialogContent>
+                      </Dialog>
                 </div>
               </div>
 


### PR DESCRIPTION
## Summary
- show follower and following lists with new components
- open lists in profile via dialog when counts clicked

## Testing
- `npx jest` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68628bdbc1f0832788f41490837c78cd