### PR TITLE
Add co-owner invite management endpoints

### DIFF
--- a/src/app/api/routes/__init__.py
+++ b/src/app/api/routes/__init__.py
@@ -1,0 +1,5 @@
+"""API routes package."""
+
+from .brands import router as brands_router
+
+__all__ = ["brands_router"]

--- a/src/app/api/routes/brands.py
+++ b/src/app/api/routes/brands.py
@@ -1,0 +1,84 @@
+"""Brand related API routes for co-owner management."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Request, status
+from pydantic import BaseModel, Field
+from starlette.responses import TemplateResponse
+
+from ...services.brands import BrandService
+
+router = APIRouter(prefix="/brands", tags=["brands"])
+
+
+class InviteCoOwnerPayload(BaseModel):
+    """Payload used when inviting a co-owner."""
+
+    username: str = Field(..., description="Username akun yang diundang sebagai co-owner")
+    note: str | None = Field(default=None, description="Catatan opsional yang dikirim bersama undangan")
+
+
+async def get_brand_service(request: Request) -> BrandService:
+    service = getattr(request.app.state, "brand_service", None)
+    if service is None:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Brand service belum dikonfigurasi",
+        )
+    if not isinstance(service, BrandService):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Brand service tidak valid",
+        )
+    return service
+
+
+@router.post("/{slug}/co-owners", response_class=TemplateResponse, name="brands:invite_co_owner")
+async def invite_co_owner(
+    request: Request,
+    slug: str,
+    payload: InviteCoOwnerPayload,
+    brand_service: BrandService = Depends(get_brand_service),
+) -> TemplateResponse:
+    """Invite a user to become a co-owner of the brand."""
+
+    return await brand_service.invite_co_owner(
+        request,
+        slug,
+        username=payload.username,
+        note=payload.note,
+    )
+
+
+@router.post(
+    "/{slug}/co-owners/{profile_id}/approve",
+    response_class=TemplateResponse,
+    name="brands:approve_co_owner",
+)
+async def approve_co_owner(
+    request: Request,
+    slug: str,
+    profile_id: UUID,
+    brand_service: BrandService = Depends(get_brand_service),
+) -> TemplateResponse:
+    """Approve a pending co-owner invitation."""
+
+    return await brand_service.approve_co_owner(request, slug, profile_id)
+
+
+@router.delete(
+    "/{slug}/co-owners/{profile_id}",
+    response_class=TemplateResponse,
+    name="brands:cancel_co_owner_invite",
+)
+async def cancel_co_owner_invite(
+    request: Request,
+    slug: str,
+    profile_id: UUID,
+    brand_service: BrandService = Depends(get_brand_service),
+) -> TemplateResponse:
+    """Cancel a pending co-owner invitation."""
+
+    return await brand_service.cancel_co_owner_invite(request, slug, profile_id)

--- a/src/app/services/__init__.py
+++ b/src/app/services/__init__.py
@@ -1,0 +1,5 @@
+"""Service layer package."""
+
+from .brands import BrandService
+
+__all__ = ["BrandService"]

--- a/src/app/services/brands.py
+++ b/src/app/services/brands.py
@@ -1,0 +1,132 @@
+"""Brand related services."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Mapping, MutableMapping, Optional
+from uuid import UUID
+
+from fastapi import HTTPException, status
+from fastapi.templating import Jinja2Templates
+from starlette.requests import Request
+from starlette.responses import TemplateResponse
+
+
+class BrandRepositoryProtocol:
+    """Protocol describing the repository used by :class:`BrandService`."""
+
+    async def get_by_slug(self, slug: str) -> Mapping[str, Any]:  # pragma: no cover - runtime dependency
+        raise NotImplementedError
+
+    async def add_pending_co_owner(
+        self, brand_id: UUID | str, profile: Mapping[str, Any], *, note: Optional[str]
+    ) -> Mapping[str, Any]:  # pragma: no cover - runtime dependency
+        raise NotImplementedError
+
+    async def approve_co_owner(
+        self, brand_id: UUID | str, profile_id: UUID | str
+    ) -> Mapping[str, Any]:  # pragma: no cover - runtime dependency
+        raise NotImplementedError
+
+    async def remove_pending_co_owner(
+        self, brand_id: UUID | str, profile_id: UUID | str
+    ) -> None:  # pragma: no cover - runtime dependency
+        raise NotImplementedError
+
+
+class ProfileServiceProtocol:
+    """Protocol describing the profile lookup service."""
+
+    async def get_by_username(self, username: str) -> Mapping[str, Any]:  # pragma: no cover - runtime dependency
+        raise NotImplementedError
+
+
+class BrandService:
+    """Application service for brand related operations."""
+
+    def __init__(
+        self,
+        brand_repository: BrandRepositoryProtocol,
+        profile_service: ProfileServiceProtocol,
+        templates: Jinja2Templates,
+    ) -> None:
+        self._brand_repository = brand_repository
+        self._profile_service = profile_service
+        self._templates = templates
+
+    async def invite_co_owner(
+        self, request: Request, slug: str, *, username: str, note: Optional[str]
+    ) -> TemplateResponse:
+        brand = await self._get_brand_or_404(slug)
+        profile = await self._profile_service.get_by_username(username)
+        await self._brand_repository.add_pending_co_owner(brand["id"], profile, note=note)
+        updated_brand = await self._brand_repository.get_by_slug(slug)
+        return self.render_team_partial(request, updated_brand, message="Undangan co-owner telah dikirim.")
+
+    async def approve_co_owner(
+        self, request: Request, slug: str, profile_id: UUID | str
+    ) -> TemplateResponse:
+        brand = await self._get_brand_or_404(slug)
+        await self._brand_repository.approve_co_owner(brand["id"], profile_id)
+        updated_brand = await self._brand_repository.get_by_slug(slug)
+        return self.render_team_partial(request, updated_brand, message="Co-owner disetujui.")
+
+    async def cancel_co_owner_invite(
+        self, request: Request, slug: str, profile_id: UUID | str
+    ) -> TemplateResponse:
+        """Cancel a pending co-owner invitation.
+
+        Parameters
+        ----------
+        request:
+            The current request instance, used for rendering HTMX partial responses.
+        slug:
+            Brand slug used to identify the brand.
+        profile_id:
+            Identifier of the profile being removed from the pending list.
+        """
+
+        brand = await self._get_brand_or_404(slug)
+        pending = _extract_pending_ids(brand.get("pending_co_owners", ()))
+        if str(profile_id) not in pending:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Undangan tidak ditemukan")
+
+        await self._brand_repository.remove_pending_co_owner(brand["id"], profile_id)
+        updated_brand = await self._brand_repository.get_by_slug(slug)
+        return self.render_team_partial(request, updated_brand, message="Undangan co-owner dibatalkan.")
+
+    async def _get_brand_or_404(self, slug: str) -> Mapping[str, Any]:
+        brand = await self._brand_repository.get_by_slug(slug)
+        if not brand:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Brand tidak ditemukan")
+        return brand
+
+    def team_partial_context(self, brand: Mapping[str, Any], *, message: Optional[str] = None) -> Dict[str, Any]:
+        """Expose a helper that prepares the context for the co-owner team partial."""
+
+        context: Dict[str, Any] = {
+            "brand": brand,
+            "co_owners": list(brand.get("co_owners", ())),
+            "pending_co_owners": list(brand.get("pending_co_owners", ())),
+        }
+        if message:
+            context["message"] = message
+        return context
+
+    def render_team_partial(
+        self, request: Request, brand: Mapping[str, Any], *, message: Optional[str] = None
+    ) -> TemplateResponse:
+        context = self.team_partial_context(brand, message=message)
+        context["request"] = request
+        return self._templates.TemplateResponse("pages/brand/partials/pending_co_owners.html", context)
+
+
+def _extract_pending_ids(pending_members: Iterable[MutableMapping[str, Any]] | None) -> set[str]:
+    if not pending_members:
+        return set()
+    ids: set[str] = set()
+    for member in pending_members:
+        profile_id = member.get("profile_id")
+        if profile_id is None:
+            continue
+        ids.add(str(profile_id))
+    return ids

--- a/src/app/templates/pages/brand/detail.html
+++ b/src/app/templates/pages/brand/detail.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="id">
+  <head>
+    <meta charset="utf-8" />
+    <title>Detail Brand - {{ brand.name }}</title>
+  </head>
+  <body class="bg-slate-50 text-slate-800">
+    <main class="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-10">
+      <header class="space-y-2">
+        <p class="text-sm uppercase tracking-wider text-slate-500">Brand</p>
+        <h1 class="text-3xl font-bold">{{ brand.name }}</h1>
+        {% if brand.tagline %}
+        <p class="text-lg text-slate-600">{{ brand.tagline }}</p>
+        {% endif %}
+      </header>
+
+      <section aria-labelledby="co-owner-section" class="rounded-2xl bg-white p-6 shadow-sm">
+        <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+          <div class="md:w-1/2">
+            <h2 id="co-owner-section" class="text-xl font-semibold">Kelola Co-owner</h2>
+            <p class="mt-2 text-sm text-slate-500">
+              Undang anggota tim baru sebagai co-owner atau kelola undangan yang masih menunggu konfirmasi.
+            </p>
+
+            <form
+              id="invite-co-owner-form"
+              class="mt-6 space-y-4"
+              hx-post="{{ url_for('brands:invite_co_owner', slug=brand.slug) }}"
+              hx-target="#pending-co-owners"
+              hx-swap="outerHTML"
+              hx-indicator="#invite-loading"
+            >
+              <div class="space-y-1">
+                <label for="co-owner-username" class="text-sm font-medium text-slate-600">Username</label>
+                <input
+                  id="co-owner-username"
+                  name="username"
+                  type="text"
+                  required
+                  class="w-full rounded-lg border border-slate-200 px-3 py-2 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                  placeholder="contoh: parfumlover"
+                />
+              </div>
+              <div class="space-y-1">
+                <label for="co-owner-note" class="text-sm font-medium text-slate-600">Catatan (opsional)</label>
+                <textarea
+                  id="co-owner-note"
+                  name="note"
+                  rows="3"
+                  class="w-full rounded-lg border border-slate-200 px-3 py-2 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                  placeholder="Sertakan pesan untuk co-owner"
+                ></textarea>
+              </div>
+              <div class="flex items-center gap-3">
+                <button
+                  type="submit"
+                  class="rounded-md bg-emerald-500 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-600 focus:outline-none focus:ring-2 focus:ring-emerald-400 focus:ring-offset-2"
+                >
+                  Kirim Undangan
+                </button>
+                <span id="invite-loading" class="htmx-indicator text-sm text-slate-400" aria-live="polite">Mengirim...</span>
+              </div>
+            </form>
+            <div id="invite-feedback" aria-live="polite" class="mt-2 text-sm text-emerald-600"></div>
+          </div>
+
+          <div class="md:w-1/2">
+            {% set pending_co_owners = pending_co_owners if pending_co_owners is defined else [] %}
+            {% set co_owners = co_owners if co_owners is defined else [] %}
+            {% set message = message if message is defined else '' %}
+            {% include "pages/brand/partials/pending_co_owners.html" %}
+          </div>
+        </div>
+      </section>
+    </main>
+  </body>
+</html>

--- a/src/app/templates/pages/brand/partials/pending_co_owners.html
+++ b/src/app/templates/pages/brand/partials/pending_co_owners.html
@@ -1,0 +1,42 @@
+<div id="pending-co-owners" class="pending-co-owners space-y-3">
+  <h3 class="text-sm font-semibold text-slate-600">Menunggu Konfirmasi</h3>
+  <ul class="space-y-2">
+    {% for invite in pending_co_owners %}
+    <li class="flex items-start justify-between gap-3 rounded-lg border border-slate-200 p-3">
+      <div class="flex-1">
+        <p class="font-medium text-slate-800">@{{ invite.username }}</p>
+        {% if invite.note %}
+        <p class="text-sm text-slate-500">{{ invite.note }}</p>
+        {% endif %}
+      </div>
+      <div class="flex flex-col items-stretch gap-2 sm:flex-row">
+        <form
+          hx-post="{{ url_for('brands:approve_co_owner', slug=brand.slug, profile_id=invite.profile_id) }}"
+          hx-target="#pending-co-owners"
+          hx-swap="outerHTML"
+          class="contents"
+        >
+          <button type="submit" class="rounded-md bg-emerald-500 px-3 py-1 text-sm font-semibold text-white hover:bg-emerald-600">
+            Setujui
+          </button>
+        </form>
+        <form
+          hx-delete="{{ url_for('brands:cancel_co_owner_invite', slug=brand.slug, profile_id=invite.profile_id) }}"
+          hx-target="#pending-co-owners"
+          hx-swap="outerHTML"
+          class="contents"
+        >
+          <button type="submit" class="rounded-md border border-red-200 px-3 py-1 text-sm font-semibold text-red-600 hover:bg-red-50">
+            Batalkan
+          </button>
+        </form>
+      </div>
+    </li>
+    {% else %}
+    <li class="rounded-lg border border-dashed border-slate-200 p-3 text-sm text-slate-500">
+      Belum ada undangan co-owner yang menunggu.
+    </li>
+    {% endfor %}
+  </ul>
+</div>
+<div id="invite-feedback" aria-live="polite" class="sr-only" hx-swap-oob="true">{{ message|default('', true) }}</div>


### PR DESCRIPTION
## Summary
- add a cancel_co_owner_invite workflow to BrandService and expose a reusable team-partial renderer
- add HTMX-friendly co-owner invite, approve, and cancel endpoints under the brand router
- refresh the brand detail template to use HTMX forms for managing pending invitations and include accessible feedback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1b22803388327855a35da0e876e8c