### PR TITLE
feat: add brand co-owner management endpoints

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -1,0 +1,1 @@
+"""Application package for SensasiWangi backend services."""

--- a/src/app/api/__init__.py
+++ b/src/app/api/__init__.py
@@ -1,0 +1,1 @@
+"""API routes package."""

--- a/src/app/api/routes/__init__.py
+++ b/src/app/api/routes/__init__.py
@@ -1,0 +1,5 @@
+"""Brand-related API routes."""
+
+from .brands import router as brand_router
+
+__all__ = ["brand_router"]

--- a/src/app/api/routes/brands.py
+++ b/src/app/api/routes/brands.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, Form, HTTPException, Request
+from fastapi.templating import Jinja2Templates
+
+from ...services import Brand, BrandRepository, BrandService, Profile
+
+
+class ProfileService:
+    """Very small profile lookup service used by the demo routes."""
+
+    def __init__(self) -> None:
+        self._profiles = {
+            "owner": Profile(id="profile-1", username="owner", display_name="Owner"),
+            "co_owner": Profile(id="profile-2", username="co_owner", display_name="Co Owner"),
+        }
+
+    def get_by_username(self, username: str) -> Profile:
+        profile = self._profiles.get(username)
+        if not profile:
+            raise HTTPException(status_code=404, detail="Profil tidak ditemukan")
+        return profile
+
+    def get_by_id(self, profile_id: str) -> Profile:
+        for profile in self._profiles.values():
+            if profile.id == profile_id:
+                return profile
+        raise HTTPException(status_code=404, detail="Profil tidak ditemukan")
+
+
+templates = Jinja2Templates(directory="src/app/templates")
+repository = BrandRepository()
+repository.seed(
+    [
+        Brand(id="brand-1", name="Sensasi Wangi", slug="sensasi-wangi"),
+    ]
+)
+brand_service = BrandService(repository, templates)
+profile_service = ProfileService()
+
+router = APIRouter(prefix="/brands", tags=["brands"])
+
+
+def get_brand_service() -> BrandService:
+    return brand_service
+
+
+def get_profile_service() -> ProfileService:
+    return profile_service
+
+
+@router.post("/{slug}/co-owners")
+async def invite_co_owner(
+    slug: str,
+    request: Request,
+    username: str = Form(...),
+    note: str | None = Form(None),
+    service: BrandService = Depends(get_brand_service),
+    profiles: ProfileService = Depends(get_profile_service),
+):
+    brand = service.get_brand_or_404(slug)
+    profile = profiles.get_by_username(username)
+    service.invite_co_owner(brand, profile, note=note)
+    return service.render_pending_team_partial(request, brand, message="Undangan co-owner dikirim")
+
+
+@router.post("/{slug}/co-owners/{profile_id}/approve")
+async def approve_co_owner(
+    slug: str,
+    profile_id: str,
+    request: Request,
+    service: BrandService = Depends(get_brand_service),
+):
+    brand = service.get_brand_or_404(slug)
+    service.approve_co_owner_invite(brand, profile_id)
+    return service.render_pending_team_partial(request, brand, message="Undangan disetujui")
+
+
+@router.delete("/{slug}/co-owners/{profile_id}")
+async def cancel_co_owner_invite(
+    slug: str,
+    profile_id: str,
+    request: Request,
+    service: BrandService = Depends(get_brand_service),
+):
+    brand = service.get_brand_or_404(slug)
+    service.cancel_co_owner_invite(brand, profile_id)
+    return service.render_pending_team_partial(request, brand, message="Undangan dibatalkan")

--- a/src/app/services/__init__.py
+++ b/src/app/services/__init__.py
@@ -1,0 +1,11 @@
+"""Service layer for backend operations."""
+
+from .brands import BrandService, BrandRepository, Brand, TeamMember, Profile
+
+__all__ = [
+    "BrandService",
+    "BrandRepository",
+    "Brand",
+    "TeamMember",
+    "Profile",
+]

--- a/src/app/services/brands.py
+++ b/src/app/services/brands.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, Iterable, List, Optional
+
+from fastapi import HTTPException
+from fastapi.templating import Jinja2Templates
+from starlette.requests import Request
+from starlette.responses import TemplateResponse
+
+
+@dataclass
+class Profile:
+    """Simple representation of a user profile."""
+
+    id: str
+    username: str
+    display_name: Optional[str] = None
+
+
+@dataclass
+class TeamMember:
+    """A brand team member, either pending or approved."""
+
+    profile_id: str
+    username: str
+    display_name: Optional[str] = None
+    note: Optional[str] = None
+    status: str = "pending"
+
+    @property
+    def is_pending(self) -> bool:
+        return self.status == "pending"
+
+    @property
+    def is_active(self) -> bool:
+        return self.status == "approved"
+
+
+@dataclass
+class Brand:
+    id: str
+    name: str
+    slug: str
+    team: List[TeamMember] = field(default_factory=list)
+
+    @property
+    def pending_members(self) -> List[TeamMember]:
+        return [member for member in self.team if member.is_pending]
+
+    @property
+    def active_members(self) -> List[TeamMember]:
+        return [member for member in self.team if member.is_active]
+
+
+class BrandRepository:
+    """Very small in-memory repository used for demonstration purposes."""
+
+    def __init__(self) -> None:
+        self._brands: Dict[str, Brand] = {}
+
+    def get_by_slug(self, slug: str) -> Optional[Brand]:
+        return self._brands.get(slug)
+
+    def save(self, brand: Brand) -> None:
+        self._brands[brand.slug] = brand
+
+    def upsert(self, brand: Brand) -> Brand:
+        self.save(brand)
+        return brand
+
+    def seed(self, brands: Iterable[Brand]) -> None:
+        for brand in brands:
+            self.save(brand)
+
+
+class BrandService:
+    """Business logic that manages brand co-owner invitations."""
+
+    def __init__(self, repository: BrandRepository, templates: Jinja2Templates) -> None:
+        self._repository = repository
+        self._templates = templates
+
+    def get_brand_or_404(self, slug: str) -> Brand:
+        brand = self._repository.get_by_slug(slug)
+        if not brand:
+            raise HTTPException(status_code=404, detail="Brand tidak ditemukan")
+        return brand
+
+    def invite_co_owner(self, brand: Brand, profile: Profile, *, note: Optional[str] = None) -> TeamMember:
+        """Add a profile as a pending co-owner for the given brand."""
+
+        if any(member.profile_id == profile.id for member in brand.team):
+            raise HTTPException(status_code=400, detail="Profil sudah menjadi bagian dari tim")
+
+        new_member = TeamMember(
+            profile_id=profile.id,
+            username=profile.username,
+            display_name=profile.display_name,
+            note=note,
+            status="pending",
+        )
+        brand.team.append(new_member)
+        self._repository.save(brand)
+        return new_member
+
+    def approve_co_owner_invite(self, brand: Brand, profile_id: str) -> TeamMember:
+        for member in brand.pending_members:
+            if member.profile_id == profile_id:
+                member.status = "approved"
+                self._repository.save(brand)
+                return member
+        raise HTTPException(status_code=404, detail="Undangan co-owner tidak ditemukan")
+
+    def cancel_co_owner_invite(self, brand: Brand, profile_id: str) -> None:
+        """Remove a pending co-owner from the brand."""
+
+        pending_before = len(brand.pending_members)
+        brand.team = [member for member in brand.team if not (member.profile_id == profile_id and member.is_pending)]
+        if len(brand.pending_members) == pending_before:
+            raise HTTPException(status_code=404, detail="Undangan co-owner tidak ditemukan")
+        self._repository.save(brand)
+
+    def render_pending_team_partial(
+        self, request: Request, brand: Brand, *, message: Optional[str] = None
+    ) -> TemplateResponse:
+        """Expose the formatted pending team section as a partial template."""
+
+        context = {
+            "request": request,
+            "brand": brand,
+            "pending_members": brand.pending_members,
+            "message": message,
+        }
+        return self._templates.TemplateResponse("partials/brand/pending_co_owners.html", context)

--- a/src/app/templates/pages/brand/detail.html
+++ b/src/app/templates/pages/brand/detail.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="id">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Detail Brand</title>
+  </head>
+  <body>
+    <main class="brand-detail">
+      <header>
+        <h1>{{ brand.name }}</h1>
+      </header>
+
+      <section class="co-owner-invite">
+        <h2>Undang Co-owner</h2>
+        <form
+          hx-post="/brands/{{ brand.slug }}/co-owners"
+          hx-target="#brand-pending-co-owners"
+          hx-swap="outerHTML"
+          class="invite-form"
+        >
+          <label for="invite-username">Nama pengguna</label>
+          <input id="invite-username" name="username" type="text" required />
+
+          <label for="invite-note">Catatan (opsional)</label>
+          <textarea id="invite-note" name="note" rows="3"></textarea>
+
+          <button type="submit">Kirim Undangan</button>
+        </form>
+        <p id="co-owner-feedback" role="status" aria-live="polite" class="feedback"></p>
+      </section>
+
+      {% include "partials/brand/pending_co_owners.html" %}
+    </main>
+  </body>
+</html>

--- a/src/app/templates/partials/brand/pending_co_owners.html
+++ b/src/app/templates/partials/brand/pending_co_owners.html
@@ -1,0 +1,38 @@
+<div id="brand-pending-co-owners" class="pending-co-owner-column">
+  <h3>Undangan Co-owner Pending</h3>
+  <p id="co-owner-feedback" hx-swap-oob="outerHTML" role="status" aria-live="polite" class="feedback">
+    {{ message or "" }}
+  </p>
+  <ul class="pending-list">
+    {% for member in pending_members %}
+      <li class="pending-item">
+        <div class="member-info">
+          <span class="member-name">{{ member.display_name or member.username }}</span>
+          {% if member.note %}
+            <span class="member-note">{{ member.note }}</span>
+          {% endif %}
+        </div>
+        <div class="member-actions">
+          <form
+            hx-post="/brands/{{ brand.slug }}/co-owners/{{ member.profile_id }}/approve"
+            hx-target="#brand-pending-co-owners"
+            hx-swap="outerHTML"
+            class="inline-form"
+          >
+            <button type="submit" class="approve-button">Setujui</button>
+          </form>
+          <form
+            hx-delete="/brands/{{ brand.slug }}/co-owners/{{ member.profile_id }}"
+            hx-target="#brand-pending-co-owners"
+            hx-swap="outerHTML"
+            class="inline-form"
+          >
+            <button type="submit" class="cancel-button">Batalkan</button>
+          </form>
+        </div>
+      </li>
+    {% else %}
+      <li class="empty">Belum ada undangan co-owner yang menunggu.</li>
+    {% endfor %}
+  </ul>
+</div>


### PR DESCRIPTION
## Summary
- extend the brand service with cancel support and a helper that renders the pending co-owner partial
- add FastAPI routes for inviting, approving, and cancelling co-owner invites that return the refreshed HTMX partial
- refactor the brand detail template to submit HTMX forms for invitations and approvals with aria-live feedback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1caca873483278d608a267689f718